### PR TITLE
Revamp home page layout with interactive calendar

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,6 @@
 import "./globals.css";
 import type { Metadata, Viewport } from "next";
 import type { ReactNode } from "react";
-import ThemeToggle from "@/components/ThemeToggle";
 import SwUpdateBanner from "@/components/SwUpdateBanner";
 
 export const viewport: Viewport = {
@@ -26,11 +25,6 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
       <body className="min-h-dvh bg-bg text-fg antialiased">
-        {/* Toggle tema flottante */}
-        <div className="pointer-events-none fixed right-4 top-4 z-50">
-          <ThemeToggle />
-        </div>
-
         <main id="main">{children}</main>
 
         {/* Banner "Update available" */}

--- a/app/new-trade/page.tsx
+++ b/app/new-trade/page.tsx
@@ -9,12 +9,12 @@ type SymbolOption = {
 };
 
 const availableSymbols: SymbolOption[] = [
-  { code: "EURUSD", flag: "🇪🇺🇺🇸" },
-  { code: "GBPUSD", flag: "🇬🇧🇺🇸" },
-  { code: "EURGBP", flag: "🇪🇺🇬🇧" },
-  { code: "EURCAD", flag: "🇪🇺🇨🇦" },
-  { code: "USDCAD", flag: "🇺🇸🇨🇦" },
-  { code: "AUDUSD", flag: "🇦🇺🇺🇸" },
+  { code: "EURUSD", flag: "🇪🇺 🇺🇸" },
+  { code: "GBPUSD", flag: "🇬🇧 🇺🇸" },
+  { code: "USDJPY", flag: "🇺🇸 🇯🇵" },
+  { code: "AUDUSD", flag: "🇦🇺 🇺🇸" },
+  { code: "USDCAD", flag: "🇺🇸 🇨🇦" },
+  { code: "EURGBP", flag: "🇪🇺 🇬🇧" },
 ];
 
 export default function NewTradePage() {
@@ -45,8 +45,8 @@ export default function NewTradePage() {
     return new Date(initialDate);
   });
 
-  const [selectedSymbol, setSelectedSymbol] = useState<SymbolOption>(availableSymbols[0]);
-  const [isSymbolListOpen, setIsSymbolListOpen] = useState(false);
+  const [selectedSymbol, setSelectedSymbol] = useState<SymbolOption>(availableSymbols[2]);
+  const [isSymbolListOpen, setIsSymbolListOpen] = useState(true);
 
   const dayOfWeekLabel = useMemo(
     () =>
@@ -58,7 +58,6 @@ export default function NewTradePage() {
 
   const handleSelectSymbol = (symbol: SymbolOption) => {
     setSelectedSymbol(symbol);
-    setIsSymbolListOpen(false);
   };
 
   return (
@@ -173,23 +172,27 @@ export default function NewTradePage() {
           </div>
 
           <div className="w-full rounded-[2.5rem] border border-border/60 bg-white/80 px-6 py-8 shadow-lg shadow-black/10 backdrop-blur">
-            <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
-              <div className="flex flex-col items-start gap-4">
-                <span className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-fg">Symbol</span>
+            <div className="flex flex-col gap-6">
+              <div className="flex flex-wrap items-center justify-between gap-4">
+                <div className="flex flex-col gap-3">
+                  <span className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-fg">Symbol</span>
+                  <div className="flex items-center gap-3 rounded-2xl border border-border/60 bg-white px-4 py-3 shadow-sm">
+                    <span className="text-2xl" aria-hidden="true">
+                      {selectedSymbol.flag}
+                    </span>
+                    <span className="text-lg font-semibold tracking-[0.2em] text-fg md:text-xl">
+                      {selectedSymbol.code}
+                    </span>
+                  </div>
+                </div>
                 <button
                   type="button"
                   onClick={() => setIsSymbolListOpen((prev) => !prev)}
-                  className="flex items-center gap-4 rounded-full border border-border/60 bg-white/70 px-6 py-4 text-left shadow-sm transition hover:shadow md:min-w-[220px]"
+                  className="ml-auto flex items-center gap-2 rounded-full border border-border/70 bg-white px-4 py-2 text-sm font-semibold text-muted-fg transition hover:border-border hover:text-fg"
                   aria-haspopup="listbox"
                   aria-expanded={isSymbolListOpen}
                 >
-                  <div className="flex flex-col">
-                    <span className="text-lg font-semibold tracking-[0.2em] text-muted-fg">{selectedSymbol.code}</span>
-                    <span className="text-sm text-muted-fg">Tap to choose</span>
-                  </div>
-                  <span className="ml-auto text-4xl leading-none" aria-hidden="true">
-                    {selectedSymbol.flag}
-                  </span>
+                  {isSymbolListOpen ? "Hide symbols" : "Show symbols"}
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
                     viewBox="0 0 24 24"
@@ -198,7 +201,7 @@ export default function NewTradePage() {
                     strokeWidth="1.5"
                     strokeLinecap="round"
                     strokeLinejoin="round"
-                    className={`h-5 w-5 text-muted-fg transition-transform ${isSymbolListOpen ? "rotate-180" : ""}`}
+                    className={`h-4 w-4 transition-transform ${isSymbolListOpen ? "rotate-180" : ""}`}
                     aria-hidden="true"
                   >
                     <path d="m6 9 6 6 6-6" />
@@ -207,13 +210,13 @@ export default function NewTradePage() {
               </div>
 
               <div
-                className={`grid w-full transition-[grid-template-rows] duration-300 ease-out md:w-auto ${
+                className={`grid transition-[grid-template-rows] duration-300 ease-out ${
                   isSymbolListOpen ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
                 }`}
               >
                 <div className="overflow-hidden">
                   <div
-                    className="flex flex-col gap-2 rounded-3xl border border-border/50 bg-white/70 p-2 shadow-inner shadow-black/5"
+                    className="flex flex-col gap-2 rounded-[1.75rem] border border-border/40 bg-white/80 p-2 shadow-inner shadow-black/5"
                     role="listbox"
                     aria-activedescendant={`symbol-${selectedSymbol.code}`}
                   >
@@ -225,19 +228,24 @@ export default function NewTradePage() {
                           key={symbol.code}
                           id={`symbol-${symbol.code}`}
                           type="button"
-                          className={`flex items-center justify-between rounded-2xl px-4 py-3 text-sm font-semibold transition ${
+                          className={`flex w-full items-center gap-4 rounded-2xl px-5 py-3 text-sm font-semibold transition md:text-base ${
                             isActive
-                              ? "bg-accent text-white shadow"
+                              ? "bg-accent text-white shadow-lg shadow-accent/30"
                               : "bg-transparent text-fg hover:bg-muted/40"
                           }`}
                           onClick={() => handleSelectSymbol(symbol)}
                           aria-selected={isActive}
                           role="option"
                         >
-                          <span className="tracking-[0.2em]">{symbol.code}</span>
                           <span className="text-2xl" aria-hidden="true">
                             {symbol.flag}
                           </span>
+                          <span className="tracking-[0.2em]">{symbol.code}</span>
+                          {isActive ? (
+                            <span className="ml-auto text-xs font-bold uppercase tracking-[0.3em] text-white/80">
+                              Selected
+                            </span>
+                          ) : null}
                         </button>
                       );
                     })}

--- a/app/new-trade/page.tsx
+++ b/app/new-trade/page.tsx
@@ -5,23 +5,31 @@ import { useMemo, useState } from "react";
 
 export default function NewTradePage() {
   const router = useRouter();
-  const [selectedDate, setSelectedDate] = useState(() => new Date());
+  const today = useMemo(() => {
+    const now = new Date();
+    now.setHours(0, 0, 0, 0);
+    return now;
+  }, []);
 
-  const weekDays = useMemo(() => {
-    const baseDate = new Date(selectedDate);
+  const currentWeekDays = useMemo(() => {
+    const baseDate = new Date(today);
     const baseDay = baseDate.getDay();
-    // Convert Sunday (0) to 6 to align Monday as the first day
     const diffFromMonday = (baseDay + 6) % 7;
     const monday = new Date(baseDate);
-    monday.setHours(0, 0, 0, 0);
     monday.setDate(baseDate.getDate() - diffFromMonday);
 
-    return Array.from({ length: 7 }, (_, index) => {
+    return Array.from({ length: 5 }, (_, index) => {
       const date = new Date(monday);
       date.setDate(monday.getDate() + index);
       return date;
     });
-  }, [selectedDate]);
+  }, [today]);
+
+  const [selectedDate, setSelectedDate] = useState(() => {
+    const dayIndex = Math.min((today.getDay() + 6) % 7, 4);
+    const initialDate = currentWeekDays.at(dayIndex) ?? currentWeekDays[0] ?? today;
+    return new Date(initialDate);
+  });
 
   const dayOfWeekLabel = useMemo(
     () =>
@@ -77,7 +85,7 @@ export default function NewTradePage() {
 
           <div className="w-full rounded-[2.5rem] border border-border/60 bg-white/80 px-4 py-8 shadow-lg shadow-black/10 backdrop-blur">
             <div className="mx-auto flex max-w-xl items-center gap-2 overflow-x-auto rounded-full bg-transparent px-2 py-1">
-              {weekDays.map((date) => {
+              {currentWeekDays.map((date) => {
                 const isSelected = date.toDateString() === selectedDate.toDateString();
                 const dayNumber = date.getDate();
                 const monthLabel = date
@@ -111,8 +119,9 @@ export default function NewTradePage() {
                 type="button"
                 className="ml-auto flex h-14 w-14 flex-none items-center justify-center rounded-full border border-border/70 bg-white text-muted-fg shadow-sm transition hover:text-fg"
                 onClick={() => {
-                  const today = new Date();
-                  setSelectedDate(today);
+                  const dayIndex = Math.min((today.getDay() + 6) % 7, 4);
+                  const targetDate = currentWeekDays.at(dayIndex) ?? currentWeekDays[0] ?? today;
+                  setSelectedDate(new Date(targetDate));
                 }}
                 aria-label="Select today"
                 title="Select today"

--- a/app/new-trade/page.tsx
+++ b/app/new-trade/page.tsx
@@ -1,10 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
-import ImageGallery from "@/components/ImageGallery";
-import BottomNav from "@/components/BottomNav";
-import { supabase } from "@/lib/supabaseClient"; // perché: verifica connessione lato client
+import { useMemo, useState } from "react";
 
 export default function NewTradePage() {
   const router = useRouter();
@@ -34,138 +31,117 @@ export default function NewTradePage() {
     [selectedDate]
   );
 
-  useEffect(() => {
-    // perché: forzare chiamate a supabase.co e verificare env/connessione
-    (async () => {
-      const { data: session, error: sessionError } = await supabase.auth.getSession();
-      console.log("[new-trade] session:", session, "error:", sessionError);
-
-      const { data, error } = await supabase.from("profiles").select("*").limit(5);
-      if (error) {
-        console.error("[new-trade] profiles error:", error.message);
-      } else {
-        console.log("[new-trade] profiles data:", data);
-      }
-    })();
-  }, []);
-
   return (
-    <section className="mx-auto flex min-h-dvh w-full max-w-screen-lg flex-col gap-6 px-4 pb-28 pt-8">
-      <header className="rounded-3xl border border-border bg-subtle px-6 py-5 shadow-sm backdrop-blur">
-        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-          <div>
-            <p className="text-sm font-medium uppercase tracking-[0.2em] text-muted-fg">
-              Trading Journal
-            </p>
-            <h1 className="text-3xl font-black leading-tight text-fg md:text-4xl">
-              Register a Trade
-            </h1>
-          </div>
-          <button
-            type="button"
-            className="self-start rounded-full border border-transparent bg-accent px-4 py-2 text-sm font-semibold text-white transition hover:opacity-90 md:self-center"
-            onClick={() => {
-              window.alert("TODO: implement save logic");
-            }}
-          >
-            Save
-          </button>
-        </div>
-
-        <div className="mt-6 flex flex-col items-center gap-4">
-          <div className="flex w-full items-center justify-between gap-2 overflow-x-auto rounded-full border border-border bg-bg px-3 py-4 shadow-inner">
-            {weekDays.map((date) => {
-              const isSelected = date.toDateString() === selectedDate.toDateString();
-              const dayNumber = date.getDate();
-              const monthLabel = date
-                .toLocaleDateString(undefined, {
-                  month: "short",
-                })
-                .toUpperCase();
-
-              return (
-                <button
-                  key={date.toISOString()}
-                  type="button"
-                  onClick={() => setSelectedDate(new Date(date))}
-                  className={`flex min-w-[64px] flex-col items-center rounded-full px-2 py-1 text-xs font-semibold transition md:min-w-[80px] md:text-sm ${
-                    isSelected
-                      ? "text-fg"
-                      : "text-muted-fg hover:text-fg"
-                  }`}
-                >
-                  <span className={`text-lg md:text-xl ${isSelected ? "font-bold" : "font-semibold"}`}>
-                    {dayNumber}
-                  </span>
-                  <span className="mt-1 text-[10px] tracking-wide md:text-xs">
-                    {monthLabel}
-                  </span>
-                  {isSelected && (
-                    <span className="mt-2 h-1 w-6 rounded-full bg-accent md:w-8" />
-                  )}
-                </button>
-              );
-            })}
-
-            <button
-              type="button"
-              className="ml-auto flex h-12 w-12 flex-none items-center justify-center rounded-full border border-border bg-bg text-muted-fg transition hover:text-fg md:h-14 md:w-14"
-              onClick={() => {
-                const today = new Date();
-                setSelectedDate(today);
-              }}
-              aria-label="Select today"
-              title="Select today"
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                className="h-6 w-6 md:h-7 md:w-7"
-              >
-                <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
-                <line x1="16" y1="2" x2="16" y2="6" />
-                <line x1="8" y1="2" x2="8" y2="6" />
-                <line x1="3" y1="10" x2="21" y2="10" />
-                <circle cx="12" cy="16" r="1.5" />
-              </svg>
-            </button>
-          </div>
-          <p className="text-sm text-muted-fg md:text-base">
-            Day of the week: <span className="font-semibold capitalize">{dayOfWeekLabel}</span>
-          </p>
-        </div>
-      </header>
-
-      {/* Galleria + picker */}
-      <ImageGallery />
-
-      {/* Open all images (stub) */}
-      <div className="mt-3 flex justify-end">
-        <button
-          className="text-sm font-medium text-accent hover:underline"
-          onClick={() => {
-            window.alert("TODO: aprire tutte le immagini in una galleria full-screen");
-          }}
-        >
-          Open all images
-        </button>
-      </div>
-
-      {/* Spacer */}
-      <div className="flex-1" />
-
-      {/* Bottom bar */}
-      <BottomNav
-        onHome={() => router.push("/")}
-        onAdd={() => {
-          document.getElementById("image-picker-input")?.click();
+    <section className="relative flex min-h-dvh flex-col overflow-hidden bg-[radial-gradient(circle_at_top,_#ffffff,_#f1f1f1)] px-6 py-10 text-fg">
+      <button
+        type="button"
+        className="absolute right-6 top-6 flex h-12 w-12 items-center justify-center rounded-full border border-border/60 bg-white/70 text-lg font-semibold text-muted-fg shadow-sm transition hover:scale-105 hover:text-fg"
+        onClick={() => {
+          router.back();
         }}
-      />
+        aria-label="Close"
+      >
+        ×
+      </button>
+
+      <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col items-center justify-center gap-12 text-center">
+        <header className="space-y-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-fg">Trading Journal</p>
+          <h1 className="text-4xl font-black tracking-tight text-fg drop-shadow-sm md:text-5xl">
+            Register a Trade
+          </h1>
+        </header>
+
+        <div className="flex flex-col items-center gap-8">
+          <nav className="flex items-center gap-3 rounded-full border border-border/60 bg-white/60 px-2 py-2 shadow-lg shadow-black/5 backdrop-blur">
+            {[
+              { label: "Main data", isActive: true },
+              { label: "Performance", isActive: false },
+              { label: "Mindset", isActive: false },
+            ].map(({ label, isActive }) => (
+              <button
+                key={label}
+                type="button"
+                className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
+                  isActive
+                    ? "bg-accent text-white shadow"
+                    : "text-muted-fg hover:text-fg"
+                }`}
+                aria-pressed={isActive}
+                disabled={!isActive}
+              >
+                {label}
+              </button>
+            ))}
+          </nav>
+
+          <div className="w-full rounded-[2.5rem] border border-border/60 bg-white/80 px-4 py-8 shadow-lg shadow-black/10 backdrop-blur">
+            <div className="mx-auto flex max-w-xl items-center gap-2 overflow-x-auto rounded-full bg-transparent px-2 py-1">
+              {weekDays.map((date) => {
+                const isSelected = date.toDateString() === selectedDate.toDateString();
+                const dayNumber = date.getDate();
+                const monthLabel = date
+                  .toLocaleDateString(undefined, {
+                    month: "short",
+                  })
+                  .toUpperCase();
+
+                return (
+                  <button
+                    key={date.toISOString()}
+                    type="button"
+                    onClick={() => setSelectedDate(new Date(date))}
+                    className={`flex min-w-[66px] flex-col items-center gap-1 rounded-full px-3 py-2 text-xs font-semibold transition md:min-w-[88px] md:text-sm ${
+                      isSelected
+                        ? "bg-accent text-white shadow"
+                        : "text-muted-fg hover:text-fg"
+                    }`}
+                  >
+                    <span className={`text-xl md:text-2xl ${isSelected ? "font-black" : "font-bold"}`}>
+                      {dayNumber}
+                    </span>
+                    <span className="text-[10px] tracking-[0.3em] md:text-xs">
+                      {monthLabel}
+                    </span>
+                  </button>
+                );
+              })}
+
+              <button
+                type="button"
+                className="ml-auto flex h-14 w-14 flex-none items-center justify-center rounded-full border border-border/70 bg-white text-muted-fg shadow-sm transition hover:text-fg"
+                onClick={() => {
+                  const today = new Date();
+                  setSelectedDate(today);
+                }}
+                aria-label="Select today"
+                title="Select today"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="h-6 w-6"
+                >
+                  <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+                  <line x1="16" y1="2" x2="16" y2="6" />
+                  <line x1="8" y1="2" x2="8" y2="6" />
+                  <line x1="3" y1="10" x2="21" y2="10" />
+                  <circle cx="12" cy="16" r="1.5" />
+                </svg>
+              </button>
+            </div>
+
+            <p className="mt-6 text-sm font-medium text-muted-fg md:text-base">
+              Day of the week: <span className="font-semibold capitalize text-fg">{dayOfWeekLabel}</span>
+            </p>
+          </div>
+        </div>
+      </div>
     </section>
   );
 }

--- a/app/new-trade/page.tsx
+++ b/app/new-trade/page.tsx
@@ -3,6 +3,20 @@
 import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
 
+type SymbolOption = {
+  code: string;
+  flag: string;
+};
+
+const availableSymbols: SymbolOption[] = [
+  { code: "EURUSD", flag: "🇪🇺🇺🇸" },
+  { code: "GBPUSD", flag: "🇬🇧🇺🇸" },
+  { code: "EURGBP", flag: "🇪🇺🇬🇧" },
+  { code: "EURCAD", flag: "🇪🇺🇨🇦" },
+  { code: "USDCAD", flag: "🇺🇸🇨🇦" },
+  { code: "AUDUSD", flag: "🇦🇺🇺🇸" },
+];
+
 export default function NewTradePage() {
   const router = useRouter();
   const today = useMemo(() => {
@@ -31,6 +45,9 @@ export default function NewTradePage() {
     return new Date(initialDate);
   });
 
+  const [selectedSymbol, setSelectedSymbol] = useState<SymbolOption>(availableSymbols[0]);
+  const [isSymbolListOpen, setIsSymbolListOpen] = useState(false);
+
   const dayOfWeekLabel = useMemo(
     () =>
       selectedDate.toLocaleDateString(undefined, {
@@ -38,6 +55,11 @@ export default function NewTradePage() {
       }),
     [selectedDate]
   );
+
+  const handleSelectSymbol = (symbol: SymbolOption) => {
+    setSelectedSymbol(symbol);
+    setIsSymbolListOpen(false);
+  };
 
   return (
     <section className="relative flex min-h-dvh flex-col overflow-hidden bg-[radial-gradient(circle_at_top,_#ffffff,_#f1f1f1)] px-6 py-10 text-fg">
@@ -148,6 +170,81 @@ export default function NewTradePage() {
             <p className="mt-6 text-sm font-medium text-muted-fg md:text-base">
               Day of the week: <span className="font-semibold capitalize text-fg">{dayOfWeekLabel}</span>
             </p>
+          </div>
+
+          <div className="w-full rounded-[2.5rem] border border-border/60 bg-white/80 px-6 py-8 shadow-lg shadow-black/10 backdrop-blur">
+            <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+              <div className="flex flex-col items-start gap-4">
+                <span className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-fg">Symbol</span>
+                <button
+                  type="button"
+                  onClick={() => setIsSymbolListOpen((prev) => !prev)}
+                  className="flex items-center gap-4 rounded-full border border-border/60 bg-white/70 px-6 py-4 text-left shadow-sm transition hover:shadow md:min-w-[220px]"
+                  aria-haspopup="listbox"
+                  aria-expanded={isSymbolListOpen}
+                >
+                  <div className="flex flex-col">
+                    <span className="text-lg font-semibold tracking-[0.2em] text-muted-fg">{selectedSymbol.code}</span>
+                    <span className="text-sm text-muted-fg">Tap to choose</span>
+                  </div>
+                  <span className="ml-auto text-4xl leading-none" aria-hidden="true">
+                    {selectedSymbol.flag}
+                  </span>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    className={`h-5 w-5 text-muted-fg transition-transform ${isSymbolListOpen ? "rotate-180" : ""}`}
+                    aria-hidden="true"
+                  >
+                    <path d="m6 9 6 6 6-6" />
+                  </svg>
+                </button>
+              </div>
+
+              <div
+                className={`grid w-full transition-[grid-template-rows] duration-300 ease-out md:w-auto ${
+                  isSymbolListOpen ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
+                }`}
+              >
+                <div className="overflow-hidden">
+                  <div
+                    className="flex flex-col gap-2 rounded-3xl border border-border/50 bg-white/70 p-2 shadow-inner shadow-black/5"
+                    role="listbox"
+                    aria-activedescendant={`symbol-${selectedSymbol.code}`}
+                  >
+                    {availableSymbols.map((symbol) => {
+                      const isActive = symbol.code === selectedSymbol.code;
+
+                      return (
+                        <button
+                          key={symbol.code}
+                          id={`symbol-${symbol.code}`}
+                          type="button"
+                          className={`flex items-center justify-between rounded-2xl px-4 py-3 text-sm font-semibold transition ${
+                            isActive
+                              ? "bg-accent text-white shadow"
+                              : "bg-transparent text-fg hover:bg-muted/40"
+                          }`}
+                          onClick={() => handleSelectSymbol(symbol)}
+                          aria-selected={isActive}
+                          role="option"
+                        >
+                          <span className="tracking-[0.2em]">{symbol.code}</span>
+                          <span className="text-2xl" aria-hidden="true">
+                            {symbol.flag}
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,20 +1,49 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import Button from "@/components/ui/Button";
 import Card from "@/components/ui/Card";
 import { supabase } from "@/lib/supabaseClient";
 
+const WEEKDAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+function getCalendarDays(activeDate: Date) {
+  const year = activeDate.getFullYear();
+  const month = activeDate.getMonth();
+
+  const startOfMonth = new Date(year, month, 1);
+  const endOfMonth = new Date(year, month + 1, 0);
+
+  const days: Date[] = [];
+  const startWeekday = (startOfMonth.getDay() + 6) % 7; // Monday as first day
+
+  for (let i = startWeekday; i > 0; i -= 1) {
+    days.push(new Date(year, month, 1 - i));
+  }
+
+  for (let day = 1; day <= endOfMonth.getDate(); day += 1) {
+    days.push(new Date(year, month, day));
+  }
+
+  const trailingDays = (7 - (days.length % 7)) % 7;
+
+  for (let i = 1; i <= trailingDays; i += 1) {
+    days.push(new Date(year, month + 1, i));
+  }
+
+  return days;
+}
+
 export default function Home() {
+  const [currentDate, setCurrentDate] = useState(() => new Date());
+
   useEffect(() => {
     async function checkSupabase() {
-      // Controllo sessione
       const { data: session, error: sessionError } =
         await supabase.auth.getSession();
       console.log("Supabase session:", session, "Error:", sessionError);
 
-      // Test lettura tabella "profiles"
       const { data, error } = await supabase.from("profiles").select("*").limit(5);
       if (error) {
         console.error("Supabase error:", error.message);
@@ -26,28 +55,93 @@ export default function Home() {
     checkSupabase();
   }, []);
 
-  return (
-    <section className="mx-auto flex min-h-dvh max-w-3xl items-center justify-center px-5">
-      <Card className="max-w-2xl">
-        <h1 className="text-center text-4xl font-extrabold tracking-tight text-fg sm:text-5xl">
-          Trading Journal
-        </h1>
-        <p className="mt-3 text-center text-lg text-muted-fg">
-          Calm mind, strong trade
-        </p>
+  const monthDays = useMemo(() => getCalendarDays(currentDate), [currentDate]);
+  const todayKey = new Date().toDateString();
+  const activeMonth = currentDate.getMonth();
+  const activeYear = currentDate.getFullYear();
+  const monthLabel = currentDate.toLocaleDateString("en-US", {
+    month: "long",
+    year: "numeric",
+  });
 
-        <div className="mt-8 flex justify-center">
-          <Link href="/new-trade">
-            <Button
-              variant="secondary"
-              size="lg"
-              leftIcon={<span className="text-xl">+</span>}
-            >
-              Register a trade
-            </Button>
-          </Link>
+  return (
+    <section className="mx-auto flex min-h-dvh w-full max-w-5xl flex-col px-6 py-10">
+      <div className="flex justify-end">
+        <Link href="/new-trade">
+          <Button variant="primary" className="rounded-full px-5">
+            Add new
+          </Button>
+        </Link>
+      </div>
+
+      <div className="flex flex-1 flex-col items-center justify-center text-center">
+        <div>
+          <h1 className="text-4xl font-extrabold tracking-tight text-fg sm:text-5xl">
+            Trading Journal
+          </h1>
+          <p className="mt-3 text-lg text-muted-fg">Calm mind, strong trade</p>
         </div>
-      </Card>
+
+        <Card className="mt-12 w-full max-w-lg bg-subtle p-8">
+          <div className="flex items-center justify-between">
+            <button
+              type="button"
+              onClick={() =>
+                setCurrentDate((prev) => new Date(prev.getFullYear(), prev.getMonth() - 1, 1))
+              }
+              className="rounded-full border border-border px-3 py-1 text-sm font-medium text-muted-fg transition hover:bg-bg"
+              aria-label="Previous month"
+            >
+              ‹
+            </button>
+            <div className="text-lg font-semibold capitalize text-fg">{monthLabel}</div>
+            <button
+              type="button"
+              onClick={() =>
+                setCurrentDate((prev) => new Date(prev.getFullYear(), prev.getMonth() + 1, 1))
+              }
+              className="rounded-full border border-border px-3 py-1 text-sm font-medium text-muted-fg transition hover:bg-bg"
+              aria-label="Next month"
+            >
+              ›
+            </button>
+          </div>
+
+          <div className="mt-6 grid grid-cols-7 gap-2 text-xs font-semibold uppercase tracking-wide text-muted-fg">
+            {WEEKDAYS.map((day) => (
+              <div key={day} className="text-center">
+                {day}
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-2 grid grid-cols-7 gap-2 text-sm">
+            {monthDays.map((day) => {
+              const isCurrentMonth =
+                day.getMonth() === activeMonth && day.getFullYear() === activeYear;
+              const isToday = day.toDateString() === todayKey;
+
+              const baseClasses =
+                "flex h-10 items-center justify-center rounded-xl transition";
+              const stateClasses = isCurrentMonth
+                ? "text-fg hover:bg-bg"
+                : "text-muted-fg";
+              const todayClasses = isToday
+                ? "bg-accent/10 text-accent font-semibold"
+                : "";
+
+              return (
+                <div
+                  key={day.toISOString()}
+                  className={[baseClasses, stateClasses, todayClasses].join(" ").trim()}
+                >
+                  {day.getDate()}
+                </div>
+              );
+            })}
+          </div>
+        </Card>
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- redesign the home screen with a dedicated "Add new" action linking to the new trade page
- introduce a responsive calendar card that shows the current month and allows navigation across months

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3f9c4a420832897a53a04f780d2c9