### PR TITLE
Add local trade persistence and listing

### DIFF
--- a/app/new-trade/page.tsx
+++ b/app/new-trade/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useMemo, useState } from "react";
+import { useMemo, useState, useTransition } from "react";
+import { saveTrade, type StoredTrade } from "@/lib/tradesStorage";
 
 type SymbolOption = {
   code: string;
@@ -47,6 +48,7 @@ export default function NewTradePage() {
 
   const [selectedSymbol, setSelectedSymbol] = useState<SymbolOption>(availableSymbols[2]);
   const [isSymbolListOpen, setIsSymbolListOpen] = useState(true);
+  const [, startNavigation] = useTransition();
 
   const dayOfWeekLabel = useMemo(
     () =>
@@ -62,16 +64,45 @@ export default function NewTradePage() {
 
   return (
     <section className="relative flex min-h-dvh flex-col overflow-hidden bg-[radial-gradient(circle_at_top,_#ffffff,_#f1f1f1)] px-6 py-10 text-fg">
-      <button
-        type="button"
-        className="absolute right-6 top-6 flex h-12 w-12 items-center justify-center rounded-full border border-border/60 bg-white/70 text-lg font-semibold text-muted-fg shadow-sm transition hover:scale-105 hover:text-fg"
-        onClick={() => {
-          router.back();
-        }}
-        aria-label="Close"
-      >
-        ×
-      </button>
+      <div className="absolute right-6 top-6 flex items-center gap-3">
+        <button
+          type="button"
+          className="rounded-full bg-accent px-6 py-2 text-sm font-semibold uppercase tracking-[0.3em] text-white shadow-sm transition hover:scale-105"
+          onClick={() => {
+            const trade: StoredTrade = {
+              id: Date.now().toString(36),
+              symbolCode: selectedSymbol.code,
+              symbolFlag: selectedSymbol.flag,
+              date: selectedDate.toISOString(),
+            };
+
+            saveTrade(trade);
+
+            startNavigation(() => {
+              router.push("/");
+            });
+
+            window.setTimeout(() => {
+              if (window.location.pathname === "/new-trade") {
+                window.location.href = "/";
+              }
+            }, 150);
+          }}
+        >
+          Save
+        </button>
+
+        <button
+          type="button"
+          className="flex h-12 w-12 items-center justify-center rounded-full border border-border/60 bg-white/70 text-lg font-semibold text-muted-fg shadow-sm transition hover:scale-105 hover:text-fg"
+          onClick={() => {
+            router.back();
+          }}
+          aria-label="Close"
+        >
+          ×
+        </button>
+      </div>
 
       <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col items-center justify-center gap-12 text-center">
         <header className="space-y-3">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import Button from "@/components/ui/Button";
 import Card from "@/components/ui/Card";
 import { supabase } from "@/lib/supabaseClient";
+import { loadTrades, type StoredTrade } from "@/lib/tradesStorage";
 
 const WEEKDAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 
@@ -37,6 +38,7 @@ function getCalendarDays(activeDate: Date) {
 
 export default function Home() {
   const [currentDate, setCurrentDate] = useState(() => new Date());
+  const [trades, setTrades] = useState<StoredTrade[]>([]);
 
   useEffect(() => {
     async function checkSupabase() {
@@ -53,6 +55,10 @@ export default function Home() {
     }
 
     checkSupabase();
+  }, []);
+
+  useEffect(() => {
+    setTrades(loadTrades());
   }, []);
 
   const monthDays = useMemo(() => getCalendarDays(currentDate), [currentDate]);
@@ -141,6 +147,50 @@ export default function Home() {
             })}
           </div>
         </Card>
+
+        <div className="mt-10 w-full max-w-lg text-left">
+          <h2 className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-fg">
+            Registered Trades
+          </h2>
+
+          {trades.length === 0 ? (
+            <p className="mt-4 rounded-3xl border border-dashed border-border/70 bg-white/50 px-6 py-8 text-center text-sm font-medium text-muted-fg">
+              No trades saved yet. Use the Add new button to register your first trade.
+            </p>
+          ) : (
+            <ol className="mt-4 space-y-3">
+              {trades.map((trade, index) => {
+                const formattedDate = new Date(trade.date).toLocaleDateString(undefined, {
+                  day: "2-digit",
+                  month: "2-digit",
+                  year: "numeric",
+                });
+
+                return (
+                  <li
+                    key={trade.id}
+                    className="flex items-center gap-4 rounded-3xl border border-border/60 bg-white/80 px-5 py-4 shadow-sm shadow-black/5"
+                  >
+                    <span className="flex h-10 w-10 flex-none items-center justify-center rounded-full bg-accent/10 text-sm font-semibold text-accent">
+                      {index + 1}
+                    </span>
+                    <span className="text-2xl" aria-hidden="true">
+                      {trade.symbolFlag}
+                    </span>
+                    <div className="flex flex-1 flex-col">
+                      <span className="text-sm font-semibold tracking-[0.2em] text-fg">
+                        {trade.symbolCode}
+                      </span>
+                    </div>
+                    <time className="text-sm font-medium text-muted-fg" dateTime={trade.date}>
+                      {formattedDate}
+                    </time>
+                  </li>
+                );
+              })}
+            </ol>
+          )}
+        </div>
       </div>
     </section>
   );

--- a/lib/tradesStorage.ts
+++ b/lib/tradesStorage.ts
@@ -1,0 +1,64 @@
+export type StoredTrade = {
+  id: string;
+  symbolCode: string;
+  symbolFlag: string;
+  date: string;
+};
+
+const STORAGE_KEY = "registeredTrades";
+
+function parseTrades(raw: string | null): StoredTrade[] {
+  if (!raw) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed
+      .map((item) => {
+        if (
+          !item ||
+          typeof item !== "object" ||
+          typeof (item as StoredTrade).id !== "string" ||
+          typeof (item as StoredTrade).symbolCode !== "string" ||
+          typeof (item as StoredTrade).symbolFlag !== "string" ||
+          typeof (item as StoredTrade).date !== "string"
+        ) {
+          return null;
+        }
+
+        return item as StoredTrade;
+      })
+      .filter((item): item is StoredTrade => item !== null);
+  } catch (error) {
+    console.error("Failed to parse stored trades", error);
+    return [];
+  }
+}
+
+export function loadTrades(): StoredTrade[] {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+  return parseTrades(raw);
+}
+
+export function saveTrade(trade: StoredTrade) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const currentTrades = loadTrades();
+  const updatedTrades = [trade, ...currentTrades];
+
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(updatedTrades));
+}
+
+export const REGISTERED_TRADES_STORAGE_KEY = STORAGE_KEY;


### PR DESCRIPTION
## Summary
- add a localStorage helper to persist saved trades
- wire the New Trade page with a Save button that stores the selected date and symbol before returning home
- display the stored trades on the home page beneath the Registered Trades heading

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e4f39d0f6883288973d20c6b55d09c