### PR TITLE
Add trade detail page with actions

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -167,24 +167,26 @@ export default function Home() {
                 });
 
                 return (
-                  <li
-                    key={trade.id}
-                    className="flex items-center gap-4 rounded-3xl border border-border/60 bg-white/80 px-5 py-4 shadow-sm shadow-black/5"
-                  >
-                    <span className="flex h-10 w-10 flex-none items-center justify-center rounded-full bg-accent/10 text-sm font-semibold text-accent">
-                      {index + 1}
-                    </span>
-                    <span className="text-2xl" aria-hidden="true">
-                      {trade.symbolFlag}
-                    </span>
-                    <div className="flex flex-1 flex-col">
-                      <span className="text-sm font-semibold tracking-[0.2em] text-fg">
-                        {trade.symbolCode}
+                  <li key={trade.id}>
+                    <Link
+                      href={`/trades/${trade.id}`}
+                      className="flex items-center gap-4 rounded-3xl border border-border/60 bg-white/80 px-5 py-4 shadow-sm shadow-black/5 transition hover:border-border hover:bg-white"
+                    >
+                      <span className="flex h-10 w-10 flex-none items-center justify-center rounded-full bg-accent/10 text-sm font-semibold text-accent">
+                        {index + 1}
                       </span>
-                    </div>
-                    <time className="text-sm font-medium text-muted-fg" dateTime={trade.date}>
-                      {formattedDate}
-                    </time>
+                      <span className="text-2xl" aria-hidden="true">
+                        {trade.symbolFlag}
+                      </span>
+                      <div className="flex flex-1 flex-col">
+                        <span className="text-sm font-semibold tracking-[0.2em] text-fg">
+                          {trade.symbolCode}
+                        </span>
+                      </div>
+                      <time className="text-sm font-medium text-muted-fg" dateTime={trade.date}>
+                        {formattedDate}
+                      </time>
+                    </Link>
                   </li>
                 );
               })}

--- a/app/trades/[id]/TradeDetailsClient.tsx
+++ b/app/trades/[id]/TradeDetailsClient.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+
+import Button from "@/components/ui/Button";
+import Card from "@/components/ui/Card";
+import { deleteTrade, getTradeById, type StoredTrade } from "@/lib/tradesStorage";
+
+type TradeDetailsClientProps = {
+  tradeId: string;
+};
+
+export default function TradeDetailsClient({ tradeId }: TradeDetailsClientProps) {
+  const router = useRouter();
+  const [trade, setTrade] = useState<StoredTrade | null>(null);
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    setTrade(getTradeById(tradeId));
+    setIsReady(true);
+  }, [tradeId]);
+
+  const formattedDate = useMemo(() => {
+    if (!trade) {
+      return "";
+    }
+
+    return new Date(trade.date).toLocaleDateString(undefined, {
+      weekday: "long",
+      year: "numeric",
+      month: "long",
+      day: "2-digit",
+    });
+  }, [trade]);
+
+  if (!isReady) {
+    return (
+      <section className="mx-auto flex min-h-dvh w-full max-w-4xl flex-col px-6 py-10">
+        <p className="text-center text-muted-fg">Loading trade…</p>
+      </section>
+    );
+  }
+
+  if (!trade) {
+    return (
+      <section className="mx-auto flex min-h-dvh w-full max-w-4xl flex-col px-6 py-10">
+        <Card className="flex flex-1 flex-col items-center justify-center gap-6 bg-white/80 p-8 text-center">
+          <div className="space-y-3">
+            <h1 className="text-2xl font-bold text-fg">Trade not found</h1>
+            <p className="text-sm text-muted-fg">
+              It looks like this trade is no longer available.
+            </p>
+          </div>
+          <Button
+            variant="primary"
+            onClick={() => {
+              router.push("/");
+            }}
+          >
+            Back to home
+          </Button>
+        </Card>
+      </section>
+    );
+  }
+
+  return (
+    <section className="mx-auto flex min-h-dvh w-full max-w-4xl flex-col px-6 py-10">
+      <header className="mb-8 flex items-start justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-fg">Trade details</p>
+          <h1 className="mt-2 text-3xl font-black text-fg">{trade.symbolCode}</h1>
+        </div>
+        <div className="flex items-center gap-3">
+          <Link href={`/new-trade?edit=${trade.id}`} className="inline-flex">
+            <Button variant="secondary" className="rounded-full px-6 uppercase tracking-[0.3em]">
+              modifica
+            </Button>
+          </Link>
+          <Button
+            variant="ghost"
+            className="rounded-full border border-border px-6 uppercase tracking-[0.3em] text-red-600 hover:text-red-700"
+            onClick={() => {
+              deleteTrade(trade.id);
+              router.push("/");
+            }}
+          >
+            elimina
+          </Button>
+          <Button
+            variant="ghost"
+            className="rounded-full border border-border px-6 uppercase tracking-[0.3em]"
+            onClick={() => {
+              router.push("/");
+            }}
+          >
+            chiudi
+          </Button>
+        </div>
+      </header>
+
+      <Card className="flex flex-col gap-6 bg-white/80 p-8">
+        <div className="flex items-center gap-4">
+          <span className="text-4xl" aria-hidden="true">
+            {trade.symbolFlag}
+          </span>
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-fg">Symbol</p>
+            <p className="text-lg font-semibold tracking-[0.2em] text-fg">{trade.symbolCode}</p>
+          </div>
+        </div>
+
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-muted-fg">Date</p>
+          <p className="text-base font-medium text-fg">{formattedDate}</p>
+        </div>
+      </Card>
+    </section>
+  );
+}

--- a/app/trades/[id]/page.tsx
+++ b/app/trades/[id]/page.tsx
@@ -1,0 +1,11 @@
+import TradeDetailsClient from "./TradeDetailsClient";
+
+type TradeDetailsPageProps = {
+  params: Promise<{ id: string }> | { id: string };
+};
+
+export default async function TradeDetailsPage({ params }: TradeDetailsPageProps) {
+  const resolvedParams = params instanceof Promise ? await params : params;
+
+  return <TradeDetailsClient tradeId={resolvedParams.id} />;
+}

--- a/lib/tradesStorage.ts
+++ b/lib/tradesStorage.ts
@@ -61,4 +61,20 @@ export function saveTrade(trade: StoredTrade) {
   window.localStorage.setItem(STORAGE_KEY, JSON.stringify(updatedTrades));
 }
 
+export function getTradeById(id: string): StoredTrade | null {
+  const trades = loadTrades();
+  return trades.find((trade) => trade.id === id) ?? null;
+}
+
+export function deleteTrade(id: string) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const currentTrades = loadTrades();
+  const updatedTrades = currentTrades.filter((trade) => trade.id !== id);
+
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(updatedTrades));
+}
+
 export const REGISTERED_TRADES_STORAGE_KEY = STORAGE_KEY;


### PR DESCRIPTION
## Summary
- wrap registered trades in links so they can be opened
- add helpers for fetching and deleting individual trades from storage
- create a trade detail page that shows stored information and exposes modify, delete, and close actions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e551c373f883288fa62e2b5747f94e