### PR TITLE
Add trade outcome indicators to calendar

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -200,7 +200,7 @@ export default function Home() {
                   <span>{day.getDate()}</span>
                   {dayOutcome ? (
                     <span
-                      className={["mt-0.5 h-1.5 w-1.5 rounded-full", outcomeIndicatorClasses]
+                      className={["mt-0.5 h-2 w-2 rounded-full", outcomeIndicatorClasses]
                         .join(" ")
                         .trim()}
                       aria-hidden="true"


### PR DESCRIPTION
## Summary
- derive calendar day outcomes from the trades' open times
- render a small colored indicator below each calendar date

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_6909e9e21194832893df43156fde7965