### PR TITLE
Fix mobile week calendar layout and label paper trades

### DIFF
--- a/app/new-trade/page.tsx
+++ b/app/new-trade/page.tsx
@@ -1118,7 +1118,7 @@ function NewTradePageContent() {
     });
 
     const buttonClasses = [
-      "flex min-w-[62px] flex-col items-center gap-1 rounded-full border border-transparent px-2 py-2 text-xs font-medium transition md:min-w-[88px] md:text-sm",
+      "flex flex-1 basis-0 min-w-0 flex-col items-center gap-1 rounded-full border border-transparent px-2 py-2 text-xs font-medium transition md:flex-none md:min-w-[88px] md:text-sm",
     ];
 
     if (isSelected) {
@@ -1951,7 +1951,7 @@ function NewTradePageContent() {
                         onPointerCancel={handleWeekPointerCancel}
                         onPointerLeave={handleWeekPointerCancel}
                       >
-                        <div className="flex w-full items-center justify-center gap-2">
+                        <div className="flex w-full items-center justify-center gap-1 sm:gap-2">
                           {visibleWeekDays.map((date) => renderWeekDayPill(date))}
                         </div>
                       </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -305,9 +305,16 @@ export default function Home() {
                             <span className="text-[1.6rem] leading-none" aria-hidden="true">
                               {trade.symbolFlag}
                             </span>
-                            <span className="text-base font-semibold tracking-[0.18em] text-fg">
-                              {trade.symbolCode}
-                            </span>
+                            <div className="flex flex-col items-center gap-0.5">
+                              <span className="text-base font-semibold tracking-[0.18em] text-fg">
+                                {trade.symbolCode}
+                              </span>
+                              {trade.isPaperTrade ? (
+                                <span className="text-[0.58rem] font-medium uppercase tracking-[0.24em] text-muted-fg">
+                                  Paper trade
+                                </span>
+                              ) : null}
+                            </div>
                           </div>
                           {outcomeLabel ? (
                             <span
@@ -343,9 +350,16 @@ export default function Home() {
                             <span className="text-2xl" aria-hidden="true">
                               {trade.symbolFlag}
                             </span>
-                            <span className="truncate text-lg font-semibold tracking-[0.16em] text-fg">
-                              {trade.symbolCode}
-                            </span>
+                            <div className="flex flex-col gap-0.5">
+                              <span className="truncate text-lg font-semibold tracking-[0.16em] text-fg">
+                                {trade.symbolCode}
+                              </span>
+                              {trade.isPaperTrade ? (
+                                <span className="text-[0.56rem] font-medium uppercase tracking-[0.24em] text-muted-fg">
+                                  Paper trade
+                                </span>
+                              ) : null}
+                            </div>
                           </div>
                         </div>
                         {shouldRenderOutcomes ? (

--- a/app/registered-trades/[tradeId]/page.tsx
+++ b/app/registered-trades/[tradeId]/page.tsx
@@ -350,7 +350,7 @@ export default function RegisteredTradePage() {
         .toUpperCase();
 
       const pillClasses = [
-        "flex min-w-[62px] flex-col items-center gap-1 rounded-full border border-transparent px-2 py-2 text-xs font-medium transition md:min-w-[88px] md:text-sm",
+        "flex flex-1 basis-0 min-w-0 flex-col items-center gap-1 rounded-full border border-transparent px-2 py-2 text-xs font-medium transition md:flex-none md:min-w-[88px] md:text-sm",
       ];
 
       if (isSelected) {
@@ -1192,7 +1192,7 @@ export default function RegisteredTradePage() {
               <div>
                 <div className="mx-auto flex w-full max-w-xl items-center gap-3">
                   <div className="relative flex min-w-0 flex-1 overflow-hidden rounded-full border border-border bg-surface px-1 py-1">
-                    <div className="flex w-full items-center justify-center gap-2">
+                    <div className="flex w-full items-center justify-center gap-1 sm:gap-2">
                       {currentWeekDays.map((date) => renderWeekDayPill(date))}
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- ensure the week selector pills flex evenly on small screens so all days remain visible
- tighten mobile spacing for the week selector without changing the desktop appearance
- surface a Paper trade label on home registered trades entries when applicable without disturbing layout

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691075e793d883288e740f83e3a7c831)