### PR TITLE
Fix mobile week calendar layout and tag paper trades

### DIFF
--- a/app/new-trade/page.tsx
+++ b/app/new-trade/page.tsx
@@ -1118,7 +1118,7 @@ function NewTradePageContent() {
     });
 
     const buttonClasses = [
-      "flex min-w-[62px] flex-col items-center gap-1 rounded-full border border-transparent px-2 py-2 text-xs font-medium transition md:min-w-[88px] md:text-sm",
+      "flex flex-1 basis-0 min-w-0 flex-col items-center gap-1 rounded-full border border-transparent px-2 py-2 text-xs font-medium transition md:flex-none md:min-w-[88px] md:text-sm",
     ];
 
     if (isSelected) {
@@ -1951,7 +1951,7 @@ function NewTradePageContent() {
                         onPointerCancel={handleWeekPointerCancel}
                         onPointerLeave={handleWeekPointerCancel}
                       >
-                        <div className="flex w-full items-center justify-center gap-2">
+                        <div className="flex w-full items-center justify-center gap-1 sm:gap-2">
                           {visibleWeekDays.map((date) => renderWeekDayPill(date))}
                         </div>
                       </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -290,7 +290,7 @@ export default function Home() {
                     >
                       {trade.isPaperTrade ? (
                         <span
-                          className="pointer-events-none absolute bottom-3 left-4 inline-flex items-center rounded-full bg-[color:rgb(var(--accent)/0.12)] px-2.5 py-1 text-[0.58rem] font-semibold uppercase tracking-[0.24em] text-accent shadow-[0_8px_18px_rgba(15,23,42,0.08)] md:bottom-auto md:left-auto md:right-5 md:top-4"
+                          className="pointer-events-none absolute bottom-3 left-4 inline-flex items-center rounded-full bg-[color:rgb(var(--accent)/0.12)] px-2.5 py-1 text-[0.58rem] font-semibold uppercase tracking-[0.24em] text-accent shadow-[0_8px_18px_rgba(15,23,42,0.08)] md:hidden"
                         >
                           Paper trade
                         </span>
@@ -379,15 +379,22 @@ export default function Home() {
                             ) : null}
                           </div>
                         ) : null}
-                        <time
-                          className="ml-auto text-sm font-medium text-muted-fg transition-colors duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] group-hover:text-fg"
-                          dateTime={trade.date}
-                        >
-                          {formattedDate}
-                        </time>
-                        <span className="ml-2 text-lg text-muted-fg transition-transform duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] group-hover:translate-x-1 group-hover:text-fg" aria-hidden="true">
-                          ↗
-                        </span>
+                        <div className="ml-auto flex items-center gap-3">
+                          {trade.isPaperTrade ? (
+                            <span className="hidden md:inline-flex items-center rounded-full bg-[color:rgb(var(--accent)/0.12)] px-2.5 py-1 text-[0.58rem] font-semibold uppercase tracking-[0.24em] text-accent shadow-[0_8px_18px_rgba(15,23,42,0.08)]">
+                              Paper trade
+                            </span>
+                          ) : null}
+                          <time
+                            className="text-sm font-medium text-muted-fg transition-colors duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] group-hover:text-fg"
+                            dateTime={trade.date}
+                          >
+                            {formattedDate}
+                          </time>
+                          <span className="text-lg text-muted-fg transition-transform duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] group-hover:translate-x-1 group-hover:text-fg" aria-hidden="true">
+                            ↗
+                          </span>
+                        </div>
                       </div>
                     </Link>
                   </li>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -286,8 +286,15 @@ export default function Home() {
                   <li key={trade.id}>
                     <Link
                       href={`/registered-trades/${trade.id}`}
-                      className="group flex flex-col gap-3 rounded-2xl border border-border bg-[color:rgb(var(--surface)/0.92)] px-4 py-3 shadow-[0_14px_32px_rgba(15,23,42,0.08)] transition-all duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] hover:-translate-y-0.5 hover:border-border hover:shadow-[0_26px_46px_rgba(15,23,42,0.16)] md:flex-row md:items-center md:gap-5 md:px-5 md:py-4"
+                      className="group relative flex flex-col gap-3 rounded-2xl border border-border bg-[color:rgb(var(--surface)/0.92)] px-4 py-3 shadow-[0_14px_32px_rgba(15,23,42,0.08)] transition-all duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] hover:-translate-y-0.5 hover:border-border hover:shadow-[0_26px_46px_rgba(15,23,42,0.16)] md:flex-row md:items-center md:gap-5 md:px-5 md:py-4"
                     >
+                      {trade.isPaperTrade ? (
+                        <span
+                          className="pointer-events-none absolute bottom-3 left-4 inline-flex items-center rounded-full bg-[color:rgb(var(--accent)/0.12)] px-2.5 py-1 text-[0.58rem] font-semibold uppercase tracking-[0.24em] text-accent shadow-[0_8px_18px_rgba(15,23,42,0.08)] md:bottom-auto md:left-auto md:right-5 md:top-4"
+                        >
+                          Paper trade
+                        </span>
+                      ) : null}
                       <div className="flex items-center justify-between md:hidden">
                         <span className="flex h-11 w-11 items-center justify-center rounded-full bg-[color:rgb(var(--accent)/0.12)] text-[0.78rem] font-semibold uppercase tracking-[0.24em] text-accent">
                           {totalTrades - index}

--- a/app/registered-trades/[tradeId]/page.tsx
+++ b/app/registered-trades/[tradeId]/page.tsx
@@ -350,7 +350,7 @@ export default function RegisteredTradePage() {
         .toUpperCase();
 
       const pillClasses = [
-        "flex min-w-[62px] flex-col items-center gap-1 rounded-full border border-transparent px-2 py-2 text-xs font-medium transition md:min-w-[88px] md:text-sm",
+        "flex flex-1 basis-0 min-w-0 flex-col items-center gap-1 rounded-full border border-transparent px-2 py-2 text-xs font-medium transition md:flex-none md:min-w-[88px] md:text-sm",
       ];
 
       if (isSelected) {
@@ -1192,7 +1192,7 @@ export default function RegisteredTradePage() {
               <div>
                 <div className="mx-auto flex w-full max-w-xl items-center gap-3">
                   <div className="relative flex min-w-0 flex-1 overflow-hidden rounded-full border border-border bg-surface px-1 py-1">
-                    <div className="flex w-full items-center justify-center gap-2">
+                    <div className="flex w-full items-center justify-center gap-1 sm:gap-2">
                       {currentWeekDays.map((date) => renderWeekDayPill(date))}
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- ensure the week selector pills flex evenly on small screens so all days remain visible
- tighten mobile spacing for the week selector without changing the desktop appearance
- display a Paper trade badge on registered trade cards in the home view when applicable

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691075e793d883288e740f83e3a7c831)