### PR TITLE
Align registered trade navigation arrows with detail panel

### DIFF
--- a/app/new-trade/page.tsx
+++ b/app/new-trade/page.tsx
@@ -2001,7 +2001,7 @@ function NewTradePageContent() {
                             setIsSymbolListOpen((prev) => !prev);
                             setIsOutcomeListOpen(false);
                           }}
-                          className="group flex h-32 w-full max-w-full flex-col items-center justify-center gap-3 rounded-2xl border border-border bg-[color:rgb(var(--surface)/0.9)] px-6 text-center shadow-[0_16px_32px_rgba(15,23,42,0.08)] transition-all duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 focus-visible:ring-offset-2 focus-visible:ring-offset-[rgb(var(--surface))] hover:-translate-y-0.5 hover:shadow-[0_24px_44px_rgba(15,23,42,0.14)] md:flex-1 md:max-w-xs lg:max-w-sm"
+                          className="group flex h-32 w-full max-w-full flex-col items-center justify-center gap-3 rounded-2xl border border-border bg-[color:rgb(var(--surface)/0.9)] px-6 text-center shadow-[0_16px_32px_rgba(15,23,42,0.08)] transition-all duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 focus-visible:ring-offset-2 focus-visible:ring-offset-[rgb(var(--surface))] hover:-translate-y-0.5 hover:shadow-[0_24px_44px_rgba(15,23,42,0.14)] md:flex-1 md:max-w-sm lg:max-w-md xl:max-w-lg"
                           aria-haspopup="listbox"
                           aria-expanded={isSymbolListOpen}
                         >
@@ -2033,8 +2033,8 @@ function NewTradePageContent() {
                               </svg>
                             </div>
                           ) : (
-                            <div className="flex flex-col items-center justify-center gap-3 text-center text-[color:rgb(var(--muted-fg)/0.6)]">
-                              <div className="flex items-center justify-center gap-2 animate-soft-fade text-xs font-medium tracking-[0.18em] transition-opacity duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] md:text-sm">
+                            <div className="flex w-full items-center justify-center text-center text-[color:rgb(var(--muted-fg)/0.6)]">
+                              <div className="flex items-center justify-center gap-2 animate-soft-fade text-[0.6rem] font-medium tracking-[0.18em] transition-opacity duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] md:text-[0.72rem]">
                                 <span>Select symbol</span>
                                 <svg
                                   xmlns="http://www.w3.org/2000/svg"
@@ -2061,7 +2061,7 @@ function NewTradePageContent() {
                             setIsOutcomeListOpen((prev) => !prev);
                             setIsSymbolListOpen(false);
                           }}
-                          className={`group flex h-32 w-full max-w-full flex-col items-center justify-center gap-3 rounded-2xl border text-center shadow-[0_16px_32px_rgba(15,23,42,0.08)] transition-all duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 focus-visible:ring-offset-2 focus-visible:ring-offset-[rgb(var(--surface))] md:flex-1 md:max-w-xs lg:max-w-sm ${
+                          className={`group flex h-32 w-full max-w-full flex-col items-center justify-center gap-3 rounded-2xl border text-center shadow-[0_16px_32px_rgba(15,23,42,0.08)] transition-all duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 focus-visible:ring-offset-2 focus-visible:ring-offset-[rgb(var(--surface))] md:w-[10.5rem] md:flex-none lg:w-[11.25rem] xl:w-[11.75rem] ${
                             tradeOutcome === "profit"
                               ? "border-[#A6E8B0] bg-[#E6F9EC] text-[#2E7D32] hover:-translate-y-0.5 hover:shadow-[0_24px_44px_rgba(15,23,42,0.14)]"
                               : tradeOutcome === "loss"
@@ -2100,7 +2100,7 @@ function NewTradePageContent() {
                             </div>
                           ) : (
                             <div className="flex flex-col items-center justify-center gap-3 text-center text-[color:rgb(var(--muted-fg)/0.6)]">
-                              <div className="flex items-center justify-center gap-2 animate-soft-fade text-xs font-medium tracking-[0.18em] transition-opacity duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] md:text-sm">
+                              <div className="flex items-center justify-center gap-2 animate-soft-fade text-[0.6rem] font-medium tracking-[0.18em] transition-opacity duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] md:text-[0.72rem]">
                                 <span>Select outcome</span>
                                 <svg
                                   xmlns="http://www.w3.org/2000/svg"
@@ -2128,7 +2128,7 @@ function NewTradePageContent() {
                             setIsSymbolListOpen(false);
                             setIsOutcomeListOpen(false);
                           }}
-                          className={`group flex h-32 w-full max-w-full flex-col items-center justify-center gap-3 rounded-2xl border text-center shadow-[0_16px_32px_rgba(15,23,42,0.08)] transition-all duration-200 ease-[cubic-bezier(0.16,1,0.3,1)] focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 focus-visible:ring-offset-2 focus-visible:ring-offset-[rgb(var(--surface))] md:flex-1 md:max-w-xs lg:max-w-sm ${
+                          className={`group flex h-32 w-full max-w-full flex-col items-center justify-center gap-3 rounded-2xl border text-center shadow-[0_16px_32px_rgba(15,23,42,0.08)] transition-all duration-200 ease-[cubic-bezier(0.16,1,0.3,1)] focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 focus-visible:ring-offset-2 focus-visible:ring-offset-[rgb(var(--surface))] md:w-[10.5rem] md:flex-none lg:w-[11.25rem] xl:w-[11.75rem] ${
                             isRealTrade
                               ? "border-[#A7C8FF] bg-[#E6EEFF] text-[#2F6FED] hover:-translate-y-0.5 hover:shadow-[0_24px_44px_rgba(15,23,42,0.14)]"
                               : "border-[#D7DDE5] bg-[#F5F7FA] text-[#6B7280] hover:-translate-y-0.5 hover:shadow-[0_24px_44px_rgba(15,23,42,0.14)]"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -372,7 +372,7 @@ export default function Home() {
                             <span className="text-[1.6rem] leading-none" aria-hidden="true">
                               {trade.symbolFlag}
                             </span>
-                            <span className="text-base font-semibold tracking-[0.18em] text-fg">
+                            <span className="text-[0.78rem] font-semibold tracking-[0.24em] text-fg">
                               {trade.symbolCode}
                             </span>
                           </div>
@@ -410,7 +410,7 @@ export default function Home() {
                             <span className="text-2xl" aria-hidden="true">
                               {trade.symbolFlag}
                             </span>
-                            <span className="truncate text-lg font-semibold tracking-[0.16em] text-fg">
+                            <span className="truncate text-[0.8rem] font-semibold tracking-[0.24em] text-fg md:text-[0.88rem]">
                               {trade.symbolCode}
                             </span>
                           </div>

--- a/app/registered-trades/[tradeId]/page.tsx
+++ b/app/registered-trades/[tradeId]/page.tsx
@@ -1581,17 +1581,19 @@ export default function RegisteredTradePage() {
                   type="button"
                   variant="ghost"
                   size="sm"
-                  className="sticky top-1/2 z-20 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full border border-border/80 bg-[color:rgb(var(--surface)/0.94)] p-0 text-muted-fg shadow-[0_10px_30px_rgba(15,23,42,0.12)] backdrop-blur hover:text-fg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[color:rgba(99,102,241,0.35)] disabled:border-border/60 disabled:text-muted-fg/60 justify-self-end -mr-2 sm:h-10 sm:w-10 md:-mr-4"
+                  className="sticky top-1/2 z-20 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full border border-[color:rgba(15,23,42,0.16)] bg-[color:rgb(var(--surface))] p-0 text-fg shadow-[0_18px_36px_rgba(15,23,42,0.18)] backdrop-blur-sm transition-[transform,box-shadow,background-color,color] duration-200 ease-out hover:-translate-x-0.5 hover:border-[color:rgba(15,23,42,0.26)] hover:shadow-[0_20px_42px_rgba(15,23,42,0.22)] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[color:rgba(99,102,241,0.35)] disabled:pointer-events-none disabled:opacity-50 justify-self-end -mr-3 md:-mr-6"
                   onClick={handleGoToPreviousTrade}
                   disabled={!canGoToPreviousTrade}
                 >
-                  <ChevronLeft aria-hidden="true" className="h-3.5 w-3.5" />
+                  <ChevronLeft aria-hidden="true" className="h-4 w-4" />
                   <span className="sr-only">Vai al trade precedente</span>
                 </Button>
 
                 <div
-                  className={`transition-opacity duration-300 ease-out ${
-                    isTradeContentVisible ? "opacity-100" : "opacity-0"
+                  className={`transform transition-all duration-500 ease-[cubic-bezier(0.25,0.8,0.25,1)] ${
+                    isTradeContentVisible
+                      ? "translate-y-0 opacity-100"
+                      : "translate-y-4 opacity-0"
                   }`}
                 >
                   {tradeDetailsPanel}
@@ -1601,11 +1603,11 @@ export default function RegisteredTradePage() {
                   type="button"
                   variant="ghost"
                   size="sm"
-                  className="sticky top-1/2 z-20 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full border border-border/80 bg-[color:rgb(var(--surface)/0.94)] p-0 text-muted-fg shadow-[0_10px_30px_rgba(15,23,42,0.12)] backdrop-blur hover:text-fg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[color:rgba(99,102,241,0.35)] disabled:border-border/60 disabled:text-muted-fg/60 justify-self-start -ml-2 sm:h-10 sm:w-10 md:-ml-4"
+                  className="sticky top-1/2 z-20 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full border border-[color:rgba(15,23,42,0.16)] bg-[color:rgb(var(--surface))] p-0 text-fg shadow-[0_18px_36px_rgba(15,23,42,0.18)] backdrop-blur-sm transition-[transform,box-shadow,background-color,color] duration-200 ease-out hover:translate-x-0.5 hover:border-[color:rgba(15,23,42,0.26)] hover:shadow-[0_20px_42px_rgba(15,23,42,0.22)] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[color:rgba(99,102,241,0.35)] disabled:pointer-events-none disabled:opacity-50 justify-self-start -ml-3 md:-ml-6"
                   onClick={handleGoToNextTrade}
                   disabled={!canGoToNextTrade}
                 >
-                  <ChevronRight aria-hidden="true" className="h-3.5 w-3.5" />
+                  <ChevronRight aria-hidden="true" className="h-4 w-4" />
                   <span className="sr-only">Vai al trade successivo</span>
                 </Button>
               </div>

--- a/app/registered-trades/[tradeId]/page.tsx
+++ b/app/registered-trades/[tradeId]/page.tsx
@@ -1577,17 +1577,15 @@ export default function RegisteredTradePage() {
           {activeTab === "main" ? (
             <div className="mx-auto w-full max-w-3xl sm:max-w-4xl">
               <div className="grid w-full grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-2 sm:gap-3 md:gap-4">
-                <Button
+                <button
                   type="button"
-                  variant="ghost"
-                  size="sm"
-                  className="sticky top-1/2 z-20 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full border border-[color:rgba(15,23,42,0.16)] bg-[color:rgb(var(--surface))] p-0 text-fg shadow-[0_18px_36px_rgba(15,23,42,0.18)] backdrop-blur-sm transition-[transform,box-shadow,background-color,color] duration-200 ease-out hover:-translate-x-0.5 hover:border-[color:rgba(15,23,42,0.26)] hover:shadow-[0_20px_42px_rgba(15,23,42,0.22)] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[color:rgba(99,102,241,0.35)] disabled:pointer-events-none disabled:opacity-50 justify-self-end -mr-3 md:-mr-6"
+                  className="sticky top-1/2 z-20 flex h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full bg-[color:rgba(255,255,255,0.6)] p-0 text-[color:rgb(var(--fg))] shadow-[0_18px_36px_rgba(15,23,42,0.18)] backdrop-blur-sm transition-colors duration-200 ease-out hover:bg-[color:rgba(255,255,255,1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[color:rgba(99,102,241,0.35)] disabled:pointer-events-none disabled:opacity-40 justify-self-end -mr-4 md:-mr-8"
                   onClick={handleGoToPreviousTrade}
                   disabled={!canGoToPreviousTrade}
                 >
                   <ChevronLeft aria-hidden="true" className="h-4 w-4" />
                   <span className="sr-only">Vai al trade precedente</span>
-                </Button>
+                </button>
 
                 <div
                   className={`transform transition-all duration-500 ease-[cubic-bezier(0.25,0.8,0.25,1)] ${
@@ -1599,17 +1597,15 @@ export default function RegisteredTradePage() {
                   {tradeDetailsPanel}
                 </div>
 
-                <Button
+                <button
                   type="button"
-                  variant="ghost"
-                  size="sm"
-                  className="sticky top-1/2 z-20 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full border border-[color:rgba(15,23,42,0.16)] bg-[color:rgb(var(--surface))] p-0 text-fg shadow-[0_18px_36px_rgba(15,23,42,0.18)] backdrop-blur-sm transition-[transform,box-shadow,background-color,color] duration-200 ease-out hover:translate-x-0.5 hover:border-[color:rgba(15,23,42,0.26)] hover:shadow-[0_20px_42px_rgba(15,23,42,0.22)] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[color:rgba(99,102,241,0.35)] disabled:pointer-events-none disabled:opacity-50 justify-self-start -ml-3 md:-ml-6"
+                  className="sticky top-1/2 z-20 flex h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full bg-[color:rgba(255,255,255,0.6)] p-0 text-[color:rgb(var(--fg))] shadow-[0_18px_36px_rgba(15,23,42,0.18)] backdrop-blur-sm transition-colors duration-200 ease-out hover:bg-[color:rgba(255,255,255,1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[color:rgba(99,102,241,0.35)] disabled:pointer-events-none disabled:opacity-40 justify-self-start -ml-4 md:-ml-8"
                   onClick={handleGoToNextTrade}
                   disabled={!canGoToNextTrade}
                 >
                   <ChevronRight aria-hidden="true" className="h-4 w-4" />
                   <span className="sr-only">Vai al trade successivo</span>
-                </Button>
+                </button>
               </div>
             </div>
           ) : (

--- a/app/registered-trades/[tradeId]/page.tsx
+++ b/app/registered-trades/[tradeId]/page.tsx
@@ -13,13 +13,21 @@ import {
   type TouchEvent as ReactTouchEvent,
   type WheelEvent as ReactWheelEvent,
 } from "react";
-import { Circle, CheckCircle, Plus, X } from "lucide-react";
+import {
+  Circle,
+  CheckCircle,
+  ChevronLeft,
+  ChevronRight,
+  Plus,
+  X,
+} from "lucide-react";
 import Button from "@/components/ui/Button";
 import { LibrarySection } from "@/components/library/LibrarySection";
 import { type LibraryCarouselItem } from "@/components/library/LibraryCarousel";
 import {
   deleteTrade,
   loadTradeById,
+  loadTrades,
   REGISTERED_TRADES_UPDATED_EVENT,
   type StoredLibraryItem,
   type StoredTrade,
@@ -168,6 +176,8 @@ export default function RegisteredTradePage() {
     createFallbackLibraryItem(),
   ]);
   const [selectedLibraryItemId, setSelectedLibraryItemId] = useState<string>("snapshot");
+  const [orderedTradeIds, setOrderedTradeIds] = useState<string[]>([]);
+  const [isTradeContentVisible, setIsTradeContentVisible] = useState(false);
   const previewContainerRef = useRef<HTMLDivElement | null>(null);
   const previewSwipeStateRef = useRef<{
     x: number;
@@ -189,6 +199,22 @@ export default function RegisteredTradePage() {
     });
     scrollUnlockTimeoutsRef.current.clear();
   }, []);
+
+  useEffect(() => {
+    if (state.status !== "ready") {
+      return;
+    }
+
+    setIsTradeContentVisible(false);
+
+    const frame = window.requestAnimationFrame(() => {
+      setIsTradeContentVisible(true);
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frame);
+    };
+  }, [state.status, state.trade?.id]);
 
   const rawTradeId = params.tradeId;
   const tradeId = Array.isArray(rawTradeId) ? rawTradeId[0] : rawTradeId;
@@ -287,6 +313,11 @@ export default function RegisteredTradePage() {
     };
   }, [clearScheduledScrollUnlocks, resetBodyScrollLock]);
 
+  const refreshTradeList = useCallback(async () => {
+    const trades = await loadTrades();
+    setOrderedTradeIds(trades.map((item) => item.id));
+  }, []);
+
   const refreshTrade = useCallback(async () => {
     if (!tradeId) {
       setState({ status: "missing", trade: null });
@@ -304,12 +335,56 @@ export default function RegisteredTradePage() {
   }, [refreshTrade]);
 
   useEffect(() => {
+    refreshTradeList();
+  }, [refreshTradeList]);
+
+  const currentTradeId = state.trade?.id ?? null;
+
+  const currentTradeIndex = useMemo(
+    () => (currentTradeId ? orderedTradeIds.indexOf(currentTradeId) : -1),
+    [orderedTradeIds, currentTradeId],
+  );
+  const previousTradeId =
+    currentTradeIndex !== -1 && currentTradeIndex < orderedTradeIds.length - 1
+      ? orderedTradeIds[currentTradeIndex + 1]
+      : null;
+  const nextTradeId =
+    currentTradeIndex > 0 ? orderedTradeIds[currentTradeIndex - 1] : null;
+
+  const goToTrade = useCallback(
+    (targetTradeId: string) => {
+      if (!targetTradeId || targetTradeId === currentTradeId) {
+        return;
+      }
+
+      router.push(`/registered-trades/${targetTradeId}`);
+    },
+    [router, currentTradeId],
+  );
+
+  const handleGoToPreviousTrade = useCallback(() => {
+    if (previousTradeId) {
+      goToTrade(previousTradeId);
+    }
+  }, [goToTrade, previousTradeId]);
+
+  const handleGoToNextTrade = useCallback(() => {
+    if (nextTradeId) {
+      goToTrade(nextTradeId);
+    }
+  }, [goToTrade, nextTradeId]);
+
+  const canGoToPreviousTrade = previousTradeId !== null;
+  const canGoToNextTrade = nextTradeId !== null;
+
+  useEffect(() => {
     if (typeof window === "undefined") {
       return;
     }
 
     const handleUpdate = () => {
       refreshTrade();
+      refreshTradeList();
     };
 
     window.addEventListener(REGISTERED_TRADES_UPDATED_EVENT, handleUpdate);
@@ -317,7 +392,7 @@ export default function RegisteredTradePage() {
     return () => {
       window.removeEventListener(REGISTERED_TRADES_UPDATED_EVENT, handleUpdate);
     };
-  }, [refreshTrade]);
+  }, [refreshTrade, refreshTradeList]);
 
   const selectedDate = useMemo(() => {
     if (state.trade?.date) {
@@ -1091,6 +1166,320 @@ export default function RegisteredTradePage() {
   const respectedRiskValue = formatOptionalText(trade.respectedRisk);
   const wouldRepeatTradeValue = formatOptionalText(trade.wouldRepeatTrade);
 
+  const tradeDetailsPanel = (
+    <div className="w-full surface-panel px-5 py-6 md:px-6 md:py-8">
+      <div className="flex flex-col gap-6">
+        <div>
+          <div className="mx-auto flex w-full max-w-xl items-center gap-3">
+            <div className="relative flex min-w-0 flex-1 overflow-hidden rounded-full border border-border bg-surface px-1 py-1">
+              <div className="flex w-full items-center justify-center gap-1 sm:gap-2">
+                {currentWeekDays.map((date) => renderWeekDayPill(date))}
+              </div>
+            </div>
+
+            <div
+              className="flex h-11 w-11 flex-none items-center justify-center rounded-full border border-border text-muted-fg transition"
+              aria-hidden="true"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="h-6 w-6"
+              >
+                <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+                <line x1="16" y1="2" x2="16" y2="6" />
+                <line x1="8" y1="2" x2="8" y2="6" />
+                <line x1="3" y1="10" x2="21" y2="10" />
+                <circle cx="12" cy="16" r="1.5" />
+              </svg>
+            </div>
+          </div>
+
+          <p className="mt-4 text-center text-sm text-muted-fg md:mt-5 md:text-base">
+            Day of the week: <span className="font-semibold text-fg">{dayOfWeekLabel}</span>
+          </p>
+        </div>
+
+        <div className="mt-10 flex w-full justify-center md:mt-12">
+          <div className="flex flex-col items-center gap-3">
+            <span className="block pb-1 text-xs font-medium uppercase tracking-[0.28em] text-muted-fg">Trade Setup</span>
+            <div className="flex w-full flex-col items-center justify-center gap-6 md:flex-row md:justify-center">
+              <div className="flex h-32 w-full max-w-full flex-col items-center justify-center gap-3 rounded-2xl border border-border bg-[color:rgb(var(--surface)/0.9)] px-6 text-center shadow-[0_16px_32px_rgba(15,23,42,0.08)] md:flex-1 md:max-w-sm lg:max-w-md xl:max-w-lg">
+                <div className="flex w-full items-center justify-center gap-3 text-fg">
+                  <span className="text-2xl" aria-hidden="true">
+                    {activeSymbol.flag}
+                  </span>
+                  <span className="text-lg font-semibold tracking-[0.2em] md:text-xl">
+                    {activeSymbol.code}
+                  </span>
+                </div>
+              </div>
+
+              <div
+                className={`flex h-32 w-full max-w-full flex-col items-center justify-center gap-3 rounded-2xl border px-4 text-center shadow-[0_16px_32px_rgba(15,23,42,0.08)] md:flex-none md:w-[10.5rem] lg:w-[11.25rem] xl:w-[11.75rem] ${
+                  trade.tradeOutcome === "profit"
+                    ? "border-[#A6E8B0] bg-[#E6F9EC] text-[#2E7D32]"
+                    : trade.tradeOutcome === "loss"
+                      ? "border-[#F5B7B7] bg-[#FCE8E8] text-[#C62828]"
+                      : "border-border bg-[color:rgb(var(--surface)/0.9)] text-[color:rgb(var(--muted-fg)/0.7)]"
+                }`}
+              >
+                {tradeOutcomeLabel ? (
+                  <span
+                    className={`text-lg font-semibold tracking-[0.14em] capitalize md:text-xl ${
+                      trade.tradeOutcome === "profit" ? "text-[#2E7D32]" : "text-[#C62828]"
+                    }`}
+                  >
+                    {tradeOutcomeLabel}
+                  </span>
+                ) : (
+                  <span className="text-[0.6rem] font-medium uppercase tracking-[0.18em] text-[color:rgb(var(--muted-fg)/0.7)] md:text-[0.72rem]">
+                    Select outcome
+                  </span>
+                )}
+              </div>
+
+              <div
+                className={`flex h-32 w-full max-w-full flex-col items-center justify-center gap-3 rounded-2xl border px-4 text-center shadow-[0_16px_32px_rgba(15,23,42,0.08)] transition-all duration-200 ease-[cubic-bezier(0.16,1,0.3,1)] md:flex-none md:w-[10.5rem] lg:w-[11.25rem] xl:w-[11.75rem] ${
+                  trade.isPaperTrade
+                    ? "border-[#D7DDE5] bg-[#F5F7FA] text-[#6B7280]"
+                    : "border-[#A7C8FF] bg-[#E6EEFF] text-[#2F6FED]"
+                }`}
+              >
+                {trade.isPaperTrade ? (
+                  <Circle
+                    className="h-5 w-5 transition-colors duration-200 ease-[cubic-bezier(0.16,1,0.3,1)]"
+                    aria-hidden="true"
+                  />
+                ) : (
+                  <CheckCircle
+                    className="h-5 w-5 transition-colors duration-200 ease-[cubic-bezier(0.16,1,0.3,1)]"
+                    aria-hidden="true"
+                  />
+                )}
+                <span className="text-sm font-medium tracking-[0.08em] transition-colors duration-200 ease-[cubic-bezier(0.16,1,0.3,1)]">
+                  {trade.isPaperTrade ? "Paper Trade" : "Real Trade"}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-col">
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="flex flex-col gap-3">
+              <span className="text-xs font-medium uppercase tracking-[0.28em] text-muted-fg">Open Time</span>
+              <div className="pointer-events-none relative flex items-center gap-3 rounded-2xl border border-border bg-surface px-4 py-3">
+                <div className="flex items-center gap-2">
+                  <span className="pill-date rounded-full px-3 py-1 text-sm font-medium md:text-base">
+                    {openTimeDisplay.dateLabel}
+                  </span>
+                  <span className="pill-time rounded-full px-3 py-1 text-sm font-semibold tracking-[0.08em] md:text-base">
+                    {openTimeDisplay.timeLabel}
+                  </span>
+                </div>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="ml-auto h-6 w-6 text-muted-fg"
+                  aria-hidden="true"
+                >
+                  <circle cx="12" cy="12" r="9" />
+                  <polyline points="12 7 12 12 15 15" />
+                </svg>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-3">
+              <span className="text-xs font-medium uppercase tracking-[0.28em] text-muted-fg">Close Time</span>
+              <div className="pointer-events-none relative flex items-center gap-3 rounded-2xl border border-border bg-surface px-4 py-3">
+                <div className="flex items-center gap-2">
+                  <span className="pill-date rounded-full px-3 py-1 text-sm font-medium md:text-base">
+                    {closeTimeDisplay.dateLabel}
+                  </span>
+                  <span className="pill-time rounded-full px-3 py-1 text-sm font-semibold tracking-[0.08em] md:text-base">
+                    {closeTimeDisplay.timeLabel}
+                  </span>
+                </div>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="ml-auto h-6 w-6 text-muted-fg"
+                  aria-hidden="true"
+                >
+                  <circle cx="12" cy="12" r="9" />
+                  <polyline points="12 7 12 12 15 15" />
+                </svg>
+              </div>
+            </div>
+          </div>
+          <p className="mt-2 text-center text-sm text-muted-fg md:mt-3 md:text-base">
+            Duration: {durationLabel}
+          </p>
+        </div>
+
+        <div className="mt-6 border-t border-border" />
+
+        <div className="flex flex-col gap-4">
+          <span className="mt-6 mb-3 block text-sm font-semibold uppercase tracking-widest text-muted-fg">
+            General Details
+          </span>
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-2">
+              <span className="text-[11px] font-medium uppercase tracking-[0.24em] text-muted-fg">Position</span>
+              <div className="rounded-2xl border border-border bg-surface px-4 py-3">
+                <span className="text-sm font-medium text-fg">{formatOptionalText(positionLabel)}</span>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <span className="text-[11px] font-medium uppercase tracking-[0.24em] text-muted-fg">Entry Price</span>
+              <div className="rounded-2xl border border-border bg-surface px-4 py-3">
+                <span className="text-sm font-medium text-fg">{entryPriceValue}</span>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <div className="grid grid-cols-1 gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,16rem)] md:gap-2">
+                <span className="text-[11px] font-medium uppercase tracking-[0.24em] text-muted-fg">
+                  Stop Loss
+                </span>
+                <span className="text-[11px] font-medium uppercase tracking-[0.24em] text-muted-fg md:justify-self-end md:text-right">
+                  Nr. Pips (SL)
+                </span>
+              </div>
+              <div className="grid grid-cols-1 gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,16rem)] md:gap-2 md:items-end">
+                <div className="rounded-2xl border border-border bg-surface px-4 py-3">
+                  <span className="text-sm font-medium text-fg">{stopLossValue}</span>
+                </div>
+                <div className="rounded-2xl border border-border bg-surface px-4 py-3 md:justify-self-end">
+                  <span className={`text-sm font-medium ${stopLossPipLabelClassName}`}>
+                    {stopLossPipDisplayValue}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            {targetDisplayConfigs.map(renderTargetDisplay)}
+
+            <div className="flex w-full items-center justify-center rounded-2xl border border-border bg-surface px-6 py-4 text-center">
+              <span className={`text-sm font-semibold ${overallPipsDetailDisplay.className}`}>
+                {overallPipsDetailDisplay.label}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div className="my-6 border-t border-border" />
+
+        <div className="flex flex-col gap-4">
+          <span className="mt-6 mb-3 block text-sm font-semibold uppercase tracking-widest text-muted-fg">
+            Risk Details
+          </span>
+          <div className="flex flex-col gap-4">
+            {riskDetailDisplayConfigs.map(renderTargetDisplay)}
+          </div>
+        </div>
+
+        <div className="mt-6 border-t border-border" />
+
+        <div className="flex flex-col gap-4">
+          <span className="mt-6 mb-3 block text-sm font-semibold uppercase tracking-widest text-muted-fg">
+            Psychology & Mindset
+          </span>
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-2">
+              <span className="text-[11px] font-medium uppercase tracking-[0.24em] text-muted-fg">
+                Mental state before the trade
+              </span>
+              <div className="rounded-2xl border border-border bg-surface px-4 py-3">
+                <span className="text-sm font-medium text-fg">{preTradeMentalStateValue}</span>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <span className="text-[11px] font-medium uppercase tracking-[0.24em] text-muted-fg">
+                Emotions during the trade
+              </span>
+              <div className="rounded-2xl border border-border bg-surface px-4 py-3">
+                <span className="text-sm font-medium text-fg">{emotionsDuringTradeValue}</span>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <span className="text-[11px] font-medium uppercase tracking-[0.24em] text-muted-fg">
+                Emotions after the trade
+              </span>
+              <div className="rounded-2xl border border-border bg-surface px-4 py-3">
+                <span className="text-sm font-medium text-fg">{emotionsAfterTradeValue}</span>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <span className="text-[11px] font-medium uppercase tracking-[0.24em] text-muted-fg">
+                Confidence level (1–10)
+              </span>
+              <div className="rounded-2xl border border-border bg-surface px-4 py-3">
+                <span className="text-sm font-medium text-fg">{confidenceLevelValue}</span>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <span className="text-[11px] font-medium uppercase tracking-[0.24em] text-muted-fg">
+                Emotional triggers
+              </span>
+              <div className="rounded-2xl border border-border bg-surface px-4 py-3">
+                <span className="text-sm font-medium text-fg">{emotionalTriggerValue}</span>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <span className="text-[11px] font-medium uppercase tracking-[0.24em] text-muted-fg">
+                Ho seguito il mio piano?
+              </span>
+              <div className="rounded-2xl border border-border bg-surface px-4 py-3">
+                <span className="text-sm font-medium text-fg">{followedPlanValue}</span>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <span className="text-[11px] font-medium uppercase tracking-[0.24em] text-muted-fg">
+                Ho rispettato il rischio prefissato?
+              </span>
+              <div className="rounded-2xl border border-border bg-surface px-4 py-3">
+                <span className="text-sm font-medium text-fg">{respectedRiskValue}</span>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <span className="text-[11px] font-medium uppercase tracking-[0.24em] text-muted-fg">
+                Rifarei questo trade?
+              </span>
+              <div className="rounded-2xl border border-border bg-surface px-4 py-3">
+                <span className="text-sm font-medium text-fg">{wouldRepeatTradeValue}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
   const handleEditTrade = () => {
     router.push(`/new-trade?tradeId=${trade.id}`);
   };
@@ -1186,318 +1575,40 @@ export default function RegisteredTradePage() {
           </nav>
 
           {activeTab === "main" ? (
-            <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 sm:max-w-4xl">
-          <div className="w-full surface-panel px-5 py-6 md:px-6 md:py-8">
-            <div className="flex flex-col gap-6">
-              <div>
-                <div className="mx-auto flex w-full max-w-xl items-center gap-3">
-                  <div className="relative flex min-w-0 flex-1 overflow-hidden rounded-full border border-border bg-surface px-1 py-1">
-                    <div className="flex w-full items-center justify-center gap-1 sm:gap-2">
-                      {currentWeekDays.map((date) => renderWeekDayPill(date))}
-                    </div>
-                  </div>
+            <div className="mx-auto w-full max-w-3xl sm:max-w-4xl">
+              <div className="grid w-full grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-2 sm:gap-3 md:gap-4">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="sticky top-1/2 z-20 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full border border-border/80 bg-[color:rgb(var(--surface)/0.94)] p-0 text-muted-fg shadow-[0_10px_30px_rgba(15,23,42,0.12)] backdrop-blur hover:text-fg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[color:rgba(99,102,241,0.35)] disabled:border-border/60 disabled:text-muted-fg/60 justify-self-end -mr-2 sm:h-10 sm:w-10 md:-mr-4"
+                  onClick={handleGoToPreviousTrade}
+                  disabled={!canGoToPreviousTrade}
+                >
+                  <ChevronLeft aria-hidden="true" className="h-3.5 w-3.5" />
+                  <span className="sr-only">Vai al trade precedente</span>
+                </Button>
 
-                  <div
-                    className="flex h-11 w-11 flex-none items-center justify-center rounded-full border border-border text-muted-fg transition"
-                    aria-hidden="true"
-                  >
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="1.5"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      className="h-6 w-6"
-                    >
-                      <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
-                      <line x1="16" y1="2" x2="16" y2="6" />
-                      <line x1="8" y1="2" x2="8" y2="6" />
-                      <line x1="3" y1="10" x2="21" y2="10" />
-                      <circle cx="12" cy="16" r="1.5" />
-                    </svg>
-                  </div>
+                <div
+                  className={`transition-opacity duration-300 ease-out ${
+                    isTradeContentVisible ? "opacity-100" : "opacity-0"
+                  }`}
+                >
+                  {tradeDetailsPanel}
                 </div>
 
-                <p className="mt-4 text-center text-sm text-muted-fg md:mt-5 md:text-base">
-                  Day of the week: <span className="font-semibold text-fg">{dayOfWeekLabel}</span>
-                </p>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="sticky top-1/2 z-20 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full border border-border/80 bg-[color:rgb(var(--surface)/0.94)] p-0 text-muted-fg shadow-[0_10px_30px_rgba(15,23,42,0.12)] backdrop-blur hover:text-fg focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[color:rgba(99,102,241,0.35)] disabled:border-border/60 disabled:text-muted-fg/60 justify-self-start -ml-2 sm:h-10 sm:w-10 md:-ml-4"
+                  onClick={handleGoToNextTrade}
+                  disabled={!canGoToNextTrade}
+                >
+                  <ChevronRight aria-hidden="true" className="h-3.5 w-3.5" />
+                  <span className="sr-only">Vai al trade successivo</span>
+                </Button>
               </div>
-
-                <div className="mt-10 flex w-full justify-center md:mt-12">
-                <div className="flex flex-col items-center gap-3">
-                  <span className="block pb-1 text-xs font-medium uppercase tracking-[0.28em] text-muted-fg">Trade Setup</span>
-                    <div className="flex w-full flex-col items-center justify-center gap-6 md:flex-row md:justify-center">
-                    <div className="flex h-32 w-full max-w-full flex-col items-center justify-center gap-3 rounded-2xl border border-border bg-[color:rgb(var(--surface)/0.9)] px-6 text-center shadow-[0_16px_32px_rgba(15,23,42,0.08)] md:flex-1 md:max-w-xs lg:max-w-sm">
-                        <div className="flex w-full items-center justify-center gap-3 text-fg">
-                          <span className="text-2xl" aria-hidden="true">
-                            {activeSymbol.flag}
-                          </span>
-                          <span className="text-lg font-semibold tracking-[0.2em] md:text-xl">
-                            {activeSymbol.code}
-                          </span>
-                        </div>
-                      </div>
-
-                      <div
-                        className={`flex h-32 w-full max-w-full flex-col items-center justify-center gap-3 rounded-2xl border px-4 text-center shadow-[0_16px_32px_rgba(15,23,42,0.08)] md:flex-1 md:max-w-xs lg:max-w-sm ${
-                          trade.tradeOutcome === "profit"
-                            ? "border-[#A6E8B0] bg-[#E6F9EC] text-[#2E7D32]"
-                            : trade.tradeOutcome === "loss"
-                              ? "border-[#F5B7B7] bg-[#FCE8E8] text-[#C62828]"
-                              : "border-border bg-[color:rgb(var(--surface)/0.9)] text-[color:rgb(var(--muted-fg)/0.7)]"
-                        }`}
-                      >
-                        {tradeOutcomeLabel ? (
-                          <span
-                            className={`text-lg font-semibold tracking-[0.14em] capitalize md:text-xl ${
-                              trade.tradeOutcome === "profit" ? "text-[#2E7D32]" : "text-[#C62828]"
-                            }`}
-                          >
-                            {tradeOutcomeLabel}
-                          </span>
-                        ) : (
-                          <span className="text-xs font-medium uppercase tracking-[0.18em] text-[color:rgb(var(--muted-fg)/0.7)]">
-                            Select outcome
-                          </span>
-                        )}
-                      </div>
-
-                      <div
-                        className={`flex h-32 w-full max-w-full flex-col items-center justify-center gap-3 rounded-2xl border px-4 text-center shadow-[0_16px_32px_rgba(15,23,42,0.08)] transition-all duration-200 ease-[cubic-bezier(0.16,1,0.3,1)] md:flex-1 md:max-w-xs lg:max-w-sm ${
-                          trade.isPaperTrade
-                            ? "border-[#D7DDE5] bg-[#F5F7FA] text-[#6B7280]"
-                            : "border-[#A7C8FF] bg-[#E6EEFF] text-[#2F6FED]"
-                        }`}
-                      >
-                        {trade.isPaperTrade ? (
-                          <Circle
-                            className="h-5 w-5 transition-colors duration-200 ease-[cubic-bezier(0.16,1,0.3,1)]"
-                            aria-hidden="true"
-                          />
-                        ) : (
-                          <CheckCircle
-                            className="h-5 w-5 transition-colors duration-200 ease-[cubic-bezier(0.16,1,0.3,1)]"
-                            aria-hidden="true"
-                          />
-                        )}
-                        <span className="text-sm font-medium tracking-[0.08em] transition-colors duration-200 ease-[cubic-bezier(0.16,1,0.3,1)]">
-                          {trade.isPaperTrade ? "Paper Trade" : "Real Trade"}
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-
-              <div className="flex flex-col">
-                <div className="grid gap-4 md:grid-cols-2">
-                  <div className="flex flex-col gap-3">
-                    <span className="text-xs font-medium uppercase tracking-[0.28em] text-muted-fg">Open Time</span>
-                    <div className="pointer-events-none relative flex items-center gap-3 rounded-2xl border border-border bg-surface px-4 py-3">
-                      <div className="flex items-center gap-2">
-                        <span className="pill-date rounded-full px-3 py-1 text-sm font-medium md:text-base">
-                          {openTimeDisplay.dateLabel}
-                        </span>
-                        <span className="pill-time rounded-full px-3 py-1 text-sm font-semibold tracking-[0.08em] md:text-base">
-                          {openTimeDisplay.timeLabel}
-                        </span>
-                      </div>
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="1.5"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        className="ml-auto h-6 w-6 text-muted-fg"
-                        aria-hidden="true"
-                      >
-                        <circle cx="12" cy="12" r="9" />
-                        <polyline points="12 7 12 12 15 15" />
-                      </svg>
-                    </div>
-                  </div>
-
-                  <div className="flex flex-col gap-3">
-                    <span className="text-xs font-medium uppercase tracking-[0.28em] text-muted-fg">Close Time</span>
-                    <div className="pointer-events-none relative flex items-center gap-3 rounded-2xl border border-border bg-surface px-4 py-3">
-                      <div className="flex items-center gap-2">
-                        <span className="pill-date rounded-full px-3 py-1 text-sm font-medium md:text-base">
-                          {closeTimeDisplay.dateLabel}
-                        </span>
-                        <span className="pill-time rounded-full px-3 py-1 text-sm font-semibold tracking-[0.08em] md:text-base">
-                          {closeTimeDisplay.timeLabel}
-                        </span>
-                      </div>
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="1.5"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        className="ml-auto h-6 w-6 text-muted-fg"
-                        aria-hidden="true"
-                      >
-                        <circle cx="12" cy="12" r="9" />
-                        <polyline points="12 7 12 12 15 15" />
-                      </svg>
-                    </div>
-                  </div>
-                </div>
-                <p className="mt-2 text-center text-sm text-muted-fg md:mt-3 md:text-base">
-                  Duration: {durationLabel}
-                </p>
-              </div>
-
-              <div className="mt-6 border-t border-border" />
-
-              <div className="flex flex-col gap-4">
-                <span className="mt-6 mb-3 block text-sm font-semibold uppercase tracking-widest text-muted-fg">
-                  General Details
-                </span>
-                <div className="flex flex-col gap-4">
-                  <div className="flex flex-col gap-2">
-                    <span className="text-[11px] font-medium uppercase tracking-[0.24em] text-muted-fg">Position</span>
-                    <div className="rounded-2xl border border-border bg-surface px-4 py-3">
-                      <span className="text-sm font-medium text-fg">{formatOptionalText(positionLabel)}</span>
-                    </div>
-                  </div>
-
-                  <div className="flex flex-col gap-2">
-                    <span className="text-[11px] font-medium uppercase tracking-[0.24em] text-muted-fg">Entry Price</span>
-                    <div className="rounded-2xl border border-border bg-surface px-4 py-3">
-                      <span className="text-sm font-medium text-fg">{entryPriceValue}</span>
-                    </div>
-                  </div>
-
-                  <div className="flex flex-col gap-2">
-                    <div className="grid grid-cols-1 gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,16rem)] md:gap-2">
-                      <span className="text-[11px] font-medium uppercase tracking-[0.24em] text-muted-fg">
-                        Stop Loss
-                      </span>
-                      <span className="text-[11px] font-medium uppercase tracking-[0.24em] text-muted-fg md:justify-self-end md:text-right">
-                        Nr. Pips (SL)
-                      </span>
-                    </div>
-                    <div className="grid grid-cols-1 gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,16rem)] md:gap-2 md:items-end">
-                      <div className="rounded-2xl border border-border bg-surface px-4 py-3">
-                        <span className="text-sm font-medium text-fg">{stopLossValue}</span>
-                      </div>
-                      <div className="rounded-2xl border border-border bg-surface px-4 py-3 md:justify-self-end">
-                        <span className={`text-sm font-medium ${stopLossPipLabelClassName}`}>
-                          {stopLossPipDisplayValue}
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-
-                  {targetDisplayConfigs.map(renderTargetDisplay)}
-
-                  <div className="flex w-full items-center justify-center rounded-2xl border border-border bg-surface px-6 py-4 text-center">
-                    <span className={`text-sm font-semibold ${overallPipsDetailDisplay.className}`}>
-                      {overallPipsDetailDisplay.label}
-                    </span>
-                  </div>
-                </div>
-              </div>
-
-              <div className="my-6 border-t border-border" />
-
-              <div className="flex flex-col gap-4">
-                <span className="mt-6 mb-3 block text-sm font-semibold uppercase tracking-widest text-muted-fg">
-                  Risk Details
-                </span>
-                <div className="flex flex-col gap-4">
-                  {riskDetailDisplayConfigs.map(renderTargetDisplay)}
-                </div>
-              </div>
-
-              <div className="mt-6 border-t border-border" />
-
-              <div className="flex flex-col gap-4">
-                <span className="mt-6 mb-3 block text-sm font-semibold uppercase tracking-widest text-muted-fg">
-                  Psychology & Mindset
-                </span>
-                <div className="flex flex-col gap-4">
-                  <div className="flex flex-col gap-2">
-                    <span className="text-[11px] font-medium uppercase tracking-[0.24em] text-muted-fg">
-                      Mental state before the trade
-                    </span>
-                    <div className="rounded-2xl border border-border bg-surface px-4 py-3">
-                      <span className="text-sm font-medium text-fg">{preTradeMentalStateValue}</span>
-                    </div>
-                  </div>
-
-                  <div className="flex flex-col gap-2">
-                    <span className="text-[11px] font-medium uppercase tracking-[0.24em] text-muted-fg">
-                      Emotions during the trade
-                    </span>
-                    <div className="rounded-2xl border border-border bg-surface px-4 py-3">
-                      <span className="text-sm font-medium text-fg">{emotionsDuringTradeValue}</span>
-                    </div>
-                  </div>
-
-                  <div className="flex flex-col gap-2">
-                    <span className="text-[11px] font-medium uppercase tracking-[0.24em] text-muted-fg">
-                      Emotions after the trade
-                    </span>
-                    <div className="rounded-2xl border border-border bg-surface px-4 py-3">
-                      <span className="text-sm font-medium text-fg">{emotionsAfterTradeValue}</span>
-                    </div>
-                  </div>
-
-                  <div className="flex flex-col gap-2">
-                    <span className="text-[11px] font-medium uppercase tracking-[0.24em] text-muted-fg">
-                      Confidence level (1–10)
-                    </span>
-                    <div className="rounded-2xl border border-border bg-surface px-4 py-3">
-                      <span className="text-sm font-medium text-fg">{confidenceLevelValue}</span>
-                    </div>
-                  </div>
-
-                  <div className="flex flex-col gap-2">
-                    <span className="text-[11px] font-medium uppercase tracking-[0.24em] text-muted-fg">
-                      Emotional triggers
-                    </span>
-                    <div className="rounded-2xl border border-border bg-surface px-4 py-3">
-                      <span className="text-sm font-medium text-fg">{emotionalTriggerValue}</span>
-                    </div>
-                  </div>
-
-                  <div className="flex flex-col gap-2">
-                    <span className="text-[11px] font-medium uppercase tracking-[0.24em] text-muted-fg">
-                      Ho seguito il mio piano?
-                    </span>
-                    <div className="rounded-2xl border border-border bg-surface px-4 py-3">
-                      <span className="text-sm font-medium text-fg">{followedPlanValue}</span>
-                    </div>
-                  </div>
-
-                  <div className="flex flex-col gap-2">
-                    <span className="text-[11px] font-medium uppercase tracking-[0.24em] text-muted-fg">
-                      Ho rispettato il rischio prefissato?
-                    </span>
-                    <div className="rounded-2xl border border-border bg-surface px-4 py-3">
-                      <span className="text-sm font-medium text-fg">{respectedRiskValue}</span>
-                    </div>
-                  </div>
-
-                  <div className="flex flex-col gap-2">
-                    <span className="text-[11px] font-medium uppercase tracking-[0.24em] text-muted-fg">
-                      Rifarei questo trade?
-                    </span>
-                    <div className="rounded-2xl border border-border bg-surface px-4 py-3">
-                      <span className="text-sm font-medium text-fg">{wouldRepeatTradeValue}</span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
             </div>
           ) : (
             <LibrarySection

--- a/app/registered-trades/[tradeId]/page.tsx
+++ b/app/registered-trades/[tradeId]/page.tsx
@@ -1579,7 +1579,7 @@ export default function RegisteredTradePage() {
               <div className="grid w-full grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-2 sm:gap-3 md:gap-4">
                 <button
                   type="button"
-                  className="sticky top-1/2 z-20 flex h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full bg-[color:rgba(255,255,255,0.6)] p-0 text-[color:rgb(var(--fg))] shadow-[0_18px_36px_rgba(15,23,42,0.18)] backdrop-blur-sm transition-colors duration-200 ease-out hover:bg-[color:rgba(255,255,255,1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[color:rgba(99,102,241,0.35)] disabled:pointer-events-none disabled:opacity-40 justify-self-end -mr-4 md:-mr-8"
+                  className="sticky top-1/2 z-20 flex h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full bg-[color:rgba(255,255,255,0.6)] p-0 text-[color:rgb(var(--fg))] shadow-[0_18px_36px_rgba(15,23,42,0.18)] backdrop-blur-sm transition-colors duration-200 ease-out hover:bg-[color:rgba(255,255,255,1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[color:rgba(99,102,241,0.35)] disabled:pointer-events-none disabled:opacity-40 justify-self-end -mr-8 md:-mr-20 lg:-mr-28"
                   onClick={handleGoToPreviousTrade}
                   disabled={!canGoToPreviousTrade}
                 >
@@ -1599,7 +1599,7 @@ export default function RegisteredTradePage() {
 
                 <button
                   type="button"
-                  className="sticky top-1/2 z-20 flex h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full bg-[color:rgba(255,255,255,0.6)] p-0 text-[color:rgb(var(--fg))] shadow-[0_18px_36px_rgba(15,23,42,0.18)] backdrop-blur-sm transition-colors duration-200 ease-out hover:bg-[color:rgba(255,255,255,1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[color:rgba(99,102,241,0.35)] disabled:pointer-events-none disabled:opacity-40 justify-self-start -ml-4 md:-ml-8"
+                  className="sticky top-1/2 z-20 flex h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full bg-[color:rgba(255,255,255,0.6)] p-0 text-[color:rgb(var(--fg))] shadow-[0_18px_36px_rgba(15,23,42,0.18)] backdrop-blur-sm transition-colors duration-200 ease-out hover:bg-[color:rgba(255,255,255,1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[color:rgba(99,102,241,0.35)] disabled:pointer-events-none disabled:opacity-40 justify-self-start -ml-8 md:-ml-20 lg:-ml-28"
                   onClick={handleGoToNextTrade}
                   disabled={!canGoToNextTrade}
                 >

--- a/lib/lucide-react.tsx
+++ b/lib/lucide-react.tsx
@@ -46,6 +46,48 @@ export const CheckCircle = forwardRef<SVGSVGElement, IconProps>(
 
 CheckCircle.displayName = "CheckCircle";
 
+export const ChevronLeft = forwardRef<SVGSVGElement, IconProps>(
+  ({ className, ...props }, ref) => (
+    <svg
+      ref={ref}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      className={className}
+      {...props}
+    >
+      <path d="m15 18-6-6 6-6" />
+    </svg>
+  ),
+);
+
+ChevronLeft.displayName = "ChevronLeft";
+
+export const ChevronRight = forwardRef<SVGSVGElement, IconProps>(
+  ({ className, ...props }, ref) => (
+    <svg
+      ref={ref}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      className={className}
+      {...props}
+    >
+      <path d="m9 6 6 6-6 6" />
+    </svg>
+  ),
+);
+
+ChevronRight.displayName = "ChevronRight";
+
 export const Plus = forwardRef<SVGSVGElement, IconProps>(
   ({ className, ...props }, ref) => (
     <svg


### PR DESCRIPTION
## Summary
- keep the registered trade navigation arrows anchored beside the main detail panel so they stay centered next to the white container while scrolling
- fade the trade detail content in after each navigation step for a smoother transition between trades

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691376289b70832888228d249ba73d3f)