### PR TITLE
Highlight last opened registered trade

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -239,7 +239,7 @@ a {
 }
 
 .last-opened-trade-card {
-  animation: last-opened-trade-scale 1.6s var(--easing-standard);
+  animation: last-opened-trade-scale 2.6s var(--easing-standard);
 }
 
 .last-opened-trade-card::after {
@@ -253,7 +253,7 @@ a {
   box-shadow:
     0 0 24px rgb(var(--accent) / 0.45),
     0 0 0 0 rgb(var(--accent) / 0.3);
-  animation: last-opened-trade-glow 1.6s ease-out;
+  animation: last-opened-trade-glow 2.6s ease-out;
 }
 
 @keyframes last-opened-trade-scale {

--- a/app/globals.css
+++ b/app/globals.css
@@ -238,6 +238,68 @@ a {
     box-shadow 260ms var(--easing-standard);
 }
 
+.last-opened-trade-card {
+  animation: last-opened-trade-scale 1.6s var(--easing-standard);
+}
+
+.last-opened-trade-card::after {
+  content: "";
+  position: absolute;
+  inset: -6px;
+  border-radius: inherit;
+  pointer-events: none;
+  opacity: 0;
+  border: 2px solid rgb(var(--accent) / 0.22);
+  box-shadow:
+    0 0 24px rgb(var(--accent) / 0.45),
+    0 0 0 0 rgb(var(--accent) / 0.3);
+  animation: last-opened-trade-glow 1.6s ease-out;
+}
+
+@keyframes last-opened-trade-scale {
+  0% {
+    transform: scale(0.985);
+  }
+
+  55% {
+    transform: scale(1.01);
+  }
+
+  100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes last-opened-trade-glow {
+  0% {
+    opacity: 0;
+    box-shadow:
+      0 0 18px rgb(var(--accent) / 0.3),
+      0 0 0 0 rgb(var(--accent) / 0.22);
+  }
+
+  35% {
+    opacity: 1;
+    box-shadow:
+      0 0 24px rgb(var(--accent) / 0.45),
+      0 0 0 2px rgb(var(--accent) / 0.2);
+  }
+
+  70% {
+    opacity: 0;
+    box-shadow:
+      0 0 0 rgb(var(--accent) / 0),
+      0 0 0 28px rgb(var(--accent) / 0);
+  }
+
+  100% {
+    opacity: 0;
+    box-shadow:
+      0 0 0 rgb(var(--accent) / 0),
+      0 0 0 0 rgb(var(--accent) / 0);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,

--- a/app/new-trade/page.tsx
+++ b/app/new-trade/page.tsx
@@ -1914,9 +1914,9 @@ function NewTradePageContent() {
         style={{ gap: "0.5cm" }}
       >
         {selectedLibraryTitle ? (
-          <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-muted-fg">
+          <h3 className="text-2xl font-semibold leading-tight text-foreground">
             {selectedLibraryTitle}
-          </p>
+          </h3>
         ) : null}
         <div
           ref={previewContainerRef}

--- a/app/new-trade/page.tsx
+++ b/app/new-trade/page.tsx
@@ -890,6 +890,19 @@ function NewTradePageContent() {
 
   const selectedImageData = selectedLibraryItem?.imageData ?? null;
   const selectedLibraryNote = selectedLibraryItem?.notes ?? "";
+  const selectedLibraryTitle = useMemo(() => {
+    if (!selectedLibraryItem) {
+      return "";
+    }
+
+    const normalizedOrderIndex = normalizeOrderIndexValue(selectedLibraryItem.orderIndex);
+    if (normalizedOrderIndex !== null) {
+      return getLibraryCardTitle(normalizedOrderIndex);
+    }
+
+    const fallbackIndex = libraryItems.findIndex((item) => item.id === selectedLibraryItem.id);
+    return getLibraryCardTitle(fallbackIndex === -1 ? 0 : fallbackIndex);
+  }, [libraryItems, selectedLibraryItem]);
 
   const canNavigateLibrary = libraryItems.length > 1;
 
@@ -1900,9 +1913,14 @@ function NewTradePageContent() {
         className="flex w-full flex-col"
         style={{ gap: "0.5cm" }}
       >
+        {selectedLibraryTitle ? (
+          <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-muted-fg">
+            {selectedLibraryTitle}
+          </p>
+        ) : null}
         <div
           ref={previewContainerRef}
-        className="w-full lg:max-w-screen-lg"
+          className="w-full lg:max-w-screen-lg"
           onWheel={handlePreviewWheel}
           onTouchStart={handlePreviewTouchStart}
           onTouchMove={handlePreviewTouchMove}

--- a/app/registered-trades/[tradeId]/page.tsx
+++ b/app/registered-trades/[tradeId]/page.tsx
@@ -16,8 +16,6 @@ import {
 import {
   Circle,
   CheckCircle,
-  ChevronLeft,
-  ChevronRight,
   Plus,
   X,
 } from "lucide-react";
@@ -26,7 +24,6 @@ import { LibrarySection } from "@/components/library/LibrarySection";
 import { type LibraryCarouselItem } from "@/components/library/LibraryCarousel";
 import {
   deleteTrade,
-  loadAdjacentTradeId,
   loadTradeById,
   REGISTERED_TRADES_UPDATED_EVENT,
   LAST_OPENED_TRADE_STORAGE_KEY,
@@ -209,10 +206,6 @@ export default function RegisteredTradePage() {
   const [isTradeContentVisible, setIsTradeContentVisible] = useState(false);
   const [isPreviewModalOpen, setIsPreviewModalOpen] = useState(false);
   const [previewAspectRatio, setPreviewAspectRatio] = useState<number | null>(null);
-  const [adjacentTradeIds, setAdjacentTradeIds] = useState<{
-    previous: string | null;
-    next: string | null;
-  }>({ previous: null, next: null });
   const previewContainerRef = useRef<HTMLDivElement | null>(null);
   const previewSwipeStateRef = useRef<{
     x: number;
@@ -381,75 +374,6 @@ export default function RegisteredTradePage() {
       // Ignore persistence failures (e.g., storage disabled)
     }
   }, [state.status, currentTradeId]);
-
-  useEffect(() => {
-    let isCancelled = false;
-
-    const loadNeighbors = async () => {
-      if (!currentTrade) {
-        if (!isCancelled) {
-          setAdjacentTradeIds({ previous: null, next: null });
-        }
-        return;
-      }
-
-      const [previous, next] = await Promise.all([
-        loadAdjacentTradeId(
-          {
-            id: currentTrade.id,
-            createdAt: currentTrade.createdAt,
-          },
-          "previous",
-        ),
-        loadAdjacentTradeId(
-          {
-            id: currentTrade.id,
-            createdAt: currentTrade.createdAt,
-          },
-          "next",
-        ),
-      ]);
-
-      if (!isCancelled) {
-        setAdjacentTradeIds({ previous, next });
-      }
-    };
-
-    loadNeighbors();
-
-    return () => {
-      isCancelled = true;
-    };
-  }, [currentTrade]);
-
-  const previousTradeId = adjacentTradeIds.previous;
-  const nextTradeId = adjacentTradeIds.next;
-
-  const goToTrade = useCallback(
-    (targetTradeId: string) => {
-      if (!targetTradeId || targetTradeId === currentTradeId) {
-        return;
-      }
-
-      router.push(`/registered-trades/${targetTradeId}`);
-    },
-    [router, currentTradeId],
-  );
-
-  const handleGoToPreviousTrade = useCallback(() => {
-    if (previousTradeId) {
-      goToTrade(previousTradeId);
-    }
-  }, [goToTrade, previousTradeId]);
-
-  const handleGoToNextTrade = useCallback(() => {
-    if (nextTradeId) {
-      goToTrade(nextTradeId);
-    }
-  }, [goToTrade, nextTradeId]);
-
-  const canGoToPreviousTrade = previousTradeId !== null;
-  const canGoToNextTrade = nextTradeId !== null;
 
   useEffect(() => {
     if (typeof window === "undefined") {
@@ -1700,18 +1624,6 @@ export default function RegisteredTradePage() {
 
             {activeTab === "main" ? (
               <div className="relative mx-auto w-full max-w-3xl sm:max-w-4xl">
-                <div className="pointer-events-none absolute inset-y-0 left-0 flex justify-end">
-                  <button
-                    type="button"
-                    className="pointer-events-auto sticky top-1/2 z-20 flex h-11 w-11 -translate-y-1/2 -translate-x-[calc(100%+4rem)] items-center justify-center rounded-full bg-[color:rgba(255,255,255,0.6)] p-0 text-[color:rgb(var(--fg))] shadow-[0_18px_36px_rgba(15,23,42,0.18)] backdrop-blur-sm transition-colors duration-200 ease-out hover:bg-[color:rgba(255,255,255,1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[color:rgba(99,102,241,0.35)] disabled:pointer-events-none disabled:opacity-40"
-                    onClick={handleGoToPreviousTrade}
-                    disabled={!canGoToPreviousTrade}
-                  >
-                    <ChevronLeft aria-hidden="true" className="h-4 w-4" />
-                    <span className="sr-only">Vai al trade precedente</span>
-                  </button>
-                </div>
-
                 <div
                   className={`transform transition-all duration-500 ease-[cubic-bezier(0.25,0.8,0.25,1)] ${
                     isTradeContentVisible
@@ -1720,18 +1632,6 @@ export default function RegisteredTradePage() {
                   }`}
                 >
                   {tradeDetailsPanel}
-                </div>
-
-                <div className="pointer-events-none absolute inset-y-0 right-0 flex justify-start">
-                  <button
-                    type="button"
-                    className="pointer-events-auto sticky top-1/2 z-20 flex h-11 w-11 -translate-y-1/2 translate-x-[calc(100%+4rem)] items-center justify-center rounded-full bg-[color:rgba(255,255,255,0.6)] p-0 text-[color:rgb(var(--fg))] shadow-[0_18px_36px_rgba(15,23,42,0.18)] backdrop-blur-sm transition-colors duration-200 ease-out hover:bg-[color:rgba(255,255,255,1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[color:rgba(99,102,241,0.35)] disabled:pointer-events-none disabled:opacity-40"
-                    onClick={handleGoToNextTrade}
-                    disabled={!canGoToNextTrade}
-                  >
-                    <ChevronRight aria-hidden="true" className="h-4 w-4" />
-                    <span className="sr-only">Vai al trade successivo</span>
-                  </button>
                 </div>
               </div>
             ) : (

--- a/app/registered-trades/[tradeId]/page.tsx
+++ b/app/registered-trades/[tradeId]/page.tsx
@@ -561,6 +561,19 @@ export default function RegisteredTradePage() {
 
   const selectedImageData = selectedLibraryItem?.imageData ?? null;
   const selectedLibraryNote = selectedLibraryItem?.notes ?? "";
+  const selectedLibraryTitle = useMemo(() => {
+    if (!selectedLibraryItem) {
+      return "";
+    }
+
+    const normalizedIndex = normalizeLibraryOrderIndex(selectedLibraryItem.orderIndex);
+    if (normalizedIndex !== null) {
+      return getLibraryCardTitle(normalizedIndex);
+    }
+
+    const fallbackIndex = libraryItems.findIndex((item) => item.id === selectedLibraryItem.id);
+    return getLibraryCardTitle(fallbackIndex === -1 ? 0 : fallbackIndex);
+  }, [libraryItems, selectedLibraryItem]);
 
   const canNavigateLibrary = libraryItems.length > 1;
 
@@ -839,6 +852,11 @@ export default function RegisteredTradePage() {
       className="flex w-full flex-col"
       style={{ gap: "0.5cm" }}
     >
+      {selectedLibraryTitle ? (
+        <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-muted-fg">
+          {selectedLibraryTitle}
+        </p>
+      ) : null}
       <div
         ref={previewContainerRef}
         className="w-full lg:max-w-screen-lg"

--- a/app/registered-trades/[tradeId]/page.tsx
+++ b/app/registered-trades/[tradeId]/page.tsx
@@ -29,6 +29,7 @@ import {
   loadAdjacentTradeId,
   loadTradeById,
   REGISTERED_TRADES_UPDATED_EVENT,
+  LAST_OPENED_TRADE_STORAGE_KEY,
   type StoredLibraryItem,
   type StoredTrade,
 } from "@/lib/tradesStorage";
@@ -364,6 +365,22 @@ export default function RegisteredTradePage() {
   }, [refreshTrade]);
   const currentTrade = state.trade ?? null;
   const currentTradeId = currentTrade?.id ?? null;
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    if (state.status !== "ready" || !currentTradeId) {
+      return;
+    }
+
+    try {
+      window.localStorage.setItem(LAST_OPENED_TRADE_STORAGE_KEY, currentTradeId);
+    } catch {
+      // Ignore persistence failures (e.g., storage disabled)
+    }
+  }, [state.status, currentTradeId]);
 
   useEffect(() => {
     let isCancelled = false;

--- a/app/registered-trades/[tradeId]/page.tsx
+++ b/app/registered-trades/[tradeId]/page.tsx
@@ -853,9 +853,9 @@ export default function RegisteredTradePage() {
       style={{ gap: "0.5cm" }}
     >
       {selectedLibraryTitle ? (
-        <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-muted-fg">
+        <h3 className="text-2xl font-semibold leading-tight text-foreground">
           {selectedLibraryTitle}
-        </p>
+        </h3>
       ) : null}
       <div
         ref={previewContainerRef}

--- a/lib/tradesStorage.ts
+++ b/lib/tradesStorage.ts
@@ -98,6 +98,7 @@ export type RemovedLibraryItem = {
 
 export const REGISTERED_TRADES_UPDATED_EVENT = "registered-trades-changed";
 export const LAST_OPENED_TRADE_STORAGE_KEY = "last-opened-trade-id";
+export const LAST_HOME_SCROLL_POSITION_STORAGE_KEY = "last-home-scroll-position";
 
 const SYMBOL_FLAGS: Record<string, string> = {
   EURUSD: "🇪🇺 🇺🇸",

--- a/lib/tradesStorage.ts
+++ b/lib/tradesStorage.ts
@@ -97,6 +97,7 @@ export type RemovedLibraryItem = {
 };
 
 export const REGISTERED_TRADES_UPDATED_EVENT = "registered-trades-changed";
+export const LAST_OPENED_TRADE_STORAGE_KEY = "last-opened-trade-id";
 
 const SYMBOL_FLAGS: Record<string, string> = {
   EURUSD: "🇪🇺 🇺🇸",


### PR DESCRIPTION
## Summary
- store the last opened trade identifier in localStorage and expose a shared storage key for reuse
- read the stored id when returning to the home page so the matching card receives a temporary highlight
- add the CSS animation used for the highlight pulse

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e013eab908328998bc52949fe9110)