### PR TITLE
Highlight last opened registered trade

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -253,3 +253,30 @@ a {
   }
 }
 
+@keyframes homeTradeCardHighlight {
+  0% {
+    box-shadow:
+      0 14px 32px rgba(15, 23, 42, 0.08),
+      0 0 0 0 rgba(var(--accent), 0.4);
+    border-color: color-mix(in srgb, rgba(var(--accent), 0.5) 80%, rgba(var(--border)) 20%);
+    transform: translateY(0);
+  }
+
+  40% {
+    box-shadow:
+      0 18px 38px rgba(15, 23, 42, 0.12),
+      0 0 0 14px rgba(var(--accent), 0.18);
+    border-color: color-mix(in srgb, rgba(var(--accent), 0.6) 70%, rgba(var(--border)) 30%);
+    transform: translateY(-4px);
+  }
+
+  100% {
+    box-shadow: 0 14px 32px rgba(15, 23, 42, 0.08);
+    border-color: color-mix(in srgb, rgba(var(--border)) 100%, transparent);
+    transform: translateY(0);
+  }
+}
+
+.home-trade-card--highlight {
+  animation: homeTradeCardHighlight 2s ease-out;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,6 +9,9 @@ import {
   REGISTERED_TRADES_UPDATED_EVENT,
   type StoredTrade,
 } from "@/lib/tradesStorage";
+import {
+  consumeLastOpenedRegisteredTradeId,
+} from "@/lib/lastOpenedTrade";
 
 const WEEKDAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 
@@ -62,6 +65,7 @@ export default function Home() {
   const [currentDate, setCurrentDate] = useState(() => new Date());
   const [trades, setTrades] = useState<StoredTrade[]>([]);
   const [tradeFilter, setTradeFilter] = useState<"all" | "real" | "paper">("all");
+  const [highlightedTradeId, setHighlightedTradeId] = useState<string | null>(null);
 
   const refreshTrades = useCallback(async () => {
     const nextTrades = await loadTrades();
@@ -87,6 +91,28 @@ export default function Home() {
       window.removeEventListener(REGISTERED_TRADES_UPDATED_EVENT, handleUpdate);
     };
   }, [refreshTrades]);
+
+  useEffect(() => {
+    const lastOpenedTradeId = consumeLastOpenedRegisteredTradeId();
+
+    if (lastOpenedTradeId) {
+      setHighlightedTradeId(lastOpenedTradeId);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!highlightedTradeId) {
+      return undefined;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setHighlightedTradeId(null);
+    }, 2200);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [highlightedTradeId]);
 
   const monthDays = useMemo(() => getCalendarDays(currentDate), [currentDate]);
   const todayKey = new Date().toDateString();
@@ -318,6 +344,7 @@ export default function Home() {
           ) : (
             <ol className="mt-4 space-y-3">
               {filteredTrades.map((trade, index) => {
+                const isHighlighted = trade.id === highlightedTradeId;
                 const formattedDate = new Date(trade.date).toLocaleDateString(undefined, {
                   day: "2-digit",
                   month: "2-digit",
@@ -346,7 +373,9 @@ export default function Home() {
                   <li key={trade.id}>
                     <Link
                       href={`/registered-trades/${trade.id}`}
-                      className="group relative flex flex-col gap-3 rounded-2xl border border-border bg-[color:rgb(var(--surface)/0.92)] px-4 py-3 shadow-[0_14px_32px_rgba(15,23,42,0.08)] transition-all duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] hover:-translate-y-0.5 hover:border-border hover:shadow-[0_26px_46px_rgba(15,23,42,0.16)] md:flex-row md:items-center md:gap-5 md:px-5 md:py-4"
+                      className={`group relative flex flex-col gap-3 rounded-2xl border border-border bg-[color:rgb(var(--surface)/0.92)] px-4 py-3 shadow-[0_14px_32px_rgba(15,23,42,0.08)] transition-all duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] hover:-translate-y-0.5 hover:border-border hover:shadow-[0_26px_46px_rgba(15,23,42,0.16)] md:flex-row md:items-center md:gap-5 md:px-5 md:py-4 ${
+                        isHighlighted ? "home-trade-card--highlight" : ""
+                      }`}
                     >
                       {trade.isPaperTrade ? (
                         <span

--- a/app/registered-trades/[tradeId]/page.tsx
+++ b/app/registered-trades/[tradeId]/page.tsx
@@ -32,6 +32,7 @@ import {
   type StoredLibraryItem,
   type StoredTrade,
 } from "@/lib/tradesStorage";
+import { saveLastOpenedRegisteredTradeId } from "@/lib/lastOpenedTrade";
 import { getLibraryCardTitle } from "@/lib/libraryCardTitles";
 import { calculateDuration } from "@/lib/duration";
 import {
@@ -364,6 +365,14 @@ export default function RegisteredTradePage() {
   }, [refreshTrade]);
   const currentTrade = state.trade ?? null;
   const currentTradeId = currentTrade?.id ?? null;
+
+  useEffect(() => {
+    if (!currentTradeId) {
+      return;
+    }
+
+    saveLastOpenedRegisteredTradeId(currentTradeId);
+  }, [currentTradeId]);
 
   useEffect(() => {
     let isCancelled = false;

--- a/lib/lastOpenedTrade.ts
+++ b/lib/lastOpenedTrade.ts
@@ -1,0 +1,36 @@
+const LAST_OPENED_REGISTERED_TRADE_STORAGE_KEY = "last-opened-registered-trade-id";
+
+function isBrowserEnvironment() {
+  return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+}
+
+export function saveLastOpenedRegisteredTradeId(tradeId: string | null | undefined) {
+  if (!tradeId || !isBrowserEnvironment()) {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(LAST_OPENED_REGISTERED_TRADE_STORAGE_KEY, tradeId);
+  } catch {
+    // Silently ignore storage write errors (private mode, quota, etc.)
+  }
+}
+
+export function consumeLastOpenedRegisteredTradeId() {
+  if (!isBrowserEnvironment()) {
+    return null;
+  }
+
+  try {
+    const storedValue = window.localStorage.getItem(LAST_OPENED_REGISTERED_TRADE_STORAGE_KEY);
+
+    if (storedValue) {
+      window.localStorage.removeItem(LAST_OPENED_REGISTERED_TRADE_STORAGE_KEY);
+      return storedValue;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add a localStorage helper so the last opened registered trade id can be persisted between pages
- save the id when a registered trade is viewed and highlight the matching card on the home feed with a short glow animation
- add the CSS animation that pulses the highlighted card to draw the eye

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e013eab908328998bc52949fe9110)