### PR TITLE
Align library carousel positioning with preview image

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -308,28 +308,46 @@ a {
     rgb(var(--surface)) 38%,
     color-mix(in srgb, rgb(var(--subtle)) 66%, rgb(var(--surface)) 34%) 100%
   );
-  border: 1px solid color-mix(in srgb, rgba(var(--border)) 75%, transparent);
+  border: 1px solid
+    color-mix(
+      in srgb,
+      color-mix(in srgb, rgb(148 163 184) 68%, rgb(100 116 139) 32%) 50%,
+      rgba(var(--border)) 50%
+    );
   box-shadow: 0 22px 56px rgba(var(--shadow-soft));
   padding-block: 0.8rem;
   padding-inline: 1rem;
+  scrollbar-width: none;
   transition: box-shadow 320ms var(--easing-standard),
     border-color 320ms var(--easing-standard),
     background 320ms var(--easing-standard);
 }
 
 .library-carousel-track:hover {
-  border-color: color-mix(in srgb, rgba(var(--border-strong)) 80%, transparent);
+  border-color: color-mix(in srgb, rgba(var(--border-strong)) 82%, rgb(148 163 184) 18%);
   box-shadow: 0 28px 70px rgba(var(--shadow));
+  scrollbar-width: thin;
+  scrollbar-color: color-mix(in srgb, rgb(var(--muted-fg)) 26%, rgb(148 163 184 / 36%)) transparent;
 }
 
 .library-carousel-track::-webkit-scrollbar {
-  height: 8px;
-  width: 8px;
+  height: 0;
+  width: 0;
+  background: transparent;
 }
 
 .library-carousel-track::-webkit-scrollbar-thumb {
   border-radius: 999px;
-  background: color-mix(in srgb, rgb(var(--muted-fg)) 18%, transparent);
+  background: transparent;
+}
+
+.library-carousel-track:hover::-webkit-scrollbar {
+  height: 8px;
+  width: 8px;
+}
+
+.library-carousel-track:hover::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, rgb(var(--muted-fg)) 20%, rgb(148 163 184 / 36%));
 }
 
 .library-carousel-card {

--- a/app/globals.css
+++ b/app/globals.css
@@ -360,6 +360,30 @@ a {
   }
 }
 
+.tab-transition-panel {
+  width: 100%;
+  opacity: 1;
+  transform: translateY(0);
+  transition: opacity 220ms ease, transform 220ms ease;
+  will-change: opacity, transform;
+}
+
+.tab-transition-panel--exiting {
+  opacity: 0;
+  transform: translateY(8px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tab-transition-panel {
+    transition-duration: 140ms;
+    transform: none;
+  }
+
+  .tab-transition-panel--exiting {
+    transform: none;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,

--- a/app/globals.css
+++ b/app/globals.css
@@ -238,6 +238,128 @@ a {
     box-shadow 260ms var(--easing-standard);
 }
 
+.last-opened-trade-card {
+  animation: last-opened-trade-scale 2.6s var(--easing-standard);
+}
+
+.last-opened-trade-card::after {
+  content: "";
+  position: absolute;
+  inset: -6px;
+  border-radius: inherit;
+  pointer-events: none;
+  opacity: 0;
+  border: 2px solid rgb(var(--accent) / 0.22);
+  box-shadow:
+    0 0 24px rgb(var(--accent) / 0.45),
+    0 0 0 0 rgb(var(--accent) / 0.3);
+  animation: last-opened-trade-glow 2.6s ease-out;
+}
+
+@keyframes last-opened-trade-scale {
+  0% {
+    transform: scale(0.985);
+  }
+
+  55% {
+    transform: scale(1.01);
+  }
+
+  100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes last-opened-trade-glow {
+  0% {
+    opacity: 0;
+    box-shadow:
+      0 0 18px rgb(var(--accent) / 0.3),
+      0 0 0 0 rgb(var(--accent) / 0.22);
+  }
+
+  35% {
+    opacity: 1;
+    box-shadow:
+      0 0 24px rgb(var(--accent) / 0.45),
+      0 0 0 2px rgb(var(--accent) / 0.2);
+  }
+
+  70% {
+    opacity: 0;
+    box-shadow:
+      0 0 0 rgb(var(--accent) / 0),
+      0 0 0 28px rgb(var(--accent) / 0);
+  }
+
+  100% {
+    opacity: 0;
+    box-shadow:
+      0 0 0 rgb(var(--accent) / 0),
+      0 0 0 0 rgb(var(--accent) / 0);
+  }
+}
+
+.library-carousel-track {
+  border-radius: var(--radius-lg);
+  background: linear-gradient(
+    165deg,
+    color-mix(in srgb, rgb(var(--subtle)) 78%, rgb(var(--surface)) 22%) 0%,
+    rgb(var(--surface)) 38%,
+    color-mix(in srgb, rgb(var(--subtle)) 66%, rgb(var(--surface)) 34%) 100%
+  );
+  border: 1px solid color-mix(in srgb, rgba(var(--border)) 75%, transparent);
+  box-shadow: 0 22px 56px rgba(var(--shadow-soft));
+  padding-block: 0.8rem;
+  padding-inline: 1rem;
+  transition: box-shadow 320ms var(--easing-standard),
+    border-color 320ms var(--easing-standard),
+    background 320ms var(--easing-standard);
+}
+
+.library-carousel-track:hover {
+  border-color: color-mix(in srgb, rgba(var(--border-strong)) 80%, transparent);
+  box-shadow: 0 28px 70px rgba(var(--shadow));
+}
+
+.library-carousel-track::-webkit-scrollbar {
+  height: 8px;
+  width: 8px;
+}
+
+.library-carousel-track::-webkit-scrollbar-thumb {
+  border-radius: 999px;
+  background: color-mix(in srgb, rgb(var(--muted-fg)) 18%, transparent);
+}
+
+.library-carousel-card {
+  transition: transform 360ms var(--easing-standard),
+    box-shadow 360ms var(--easing-standard),
+    filter 360ms var(--easing-standard),
+    opacity 360ms var(--easing-standard);
+}
+
+.library-carousel-card-wrapper[data-reordering="true"] .library-carousel-card {
+  animation: library-card-reorder 520ms var(--easing-standard);
+}
+
+@keyframes library-card-reorder {
+  0% {
+    transform: translateY(6px) scale(0.97);
+    box-shadow: 0 14px 38px -26px rgb(15 23 42 / 0.35);
+  }
+
+  60% {
+    transform: translateY(-2px) scale(1.01);
+    box-shadow: 0 20px 60px -30px rgb(15 23 42 / 0.38);
+  }
+
+  100% {
+    transform: translateY(0) scale(1);
+    box-shadow: inherit;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,

--- a/app/new-trade/page.tsx
+++ b/app/new-trade/page.tsx
@@ -890,6 +890,19 @@ function NewTradePageContent() {
 
   const selectedImageData = selectedLibraryItem?.imageData ?? null;
   const selectedLibraryNote = selectedLibraryItem?.notes ?? "";
+  const selectedLibraryTitle = useMemo(() => {
+    if (!selectedLibraryItem) {
+      return "";
+    }
+
+    const normalizedOrderIndex = normalizeOrderIndexValue(selectedLibraryItem.orderIndex);
+    if (normalizedOrderIndex !== null) {
+      return getLibraryCardTitle(normalizedOrderIndex);
+    }
+
+    const fallbackIndex = libraryItems.findIndex((item) => item.id === selectedLibraryItem.id);
+    return getLibraryCardTitle(fallbackIndex === -1 ? 0 : fallbackIndex);
+  }, [libraryItems, selectedLibraryItem]);
 
   const canNavigateLibrary = libraryItems.length > 1;
 
@@ -1900,9 +1913,14 @@ function NewTradePageContent() {
         className="flex w-full flex-col"
         style={{ gap: "0.5cm" }}
       >
+        {selectedLibraryTitle ? (
+          <h3 className="text-2xl font-semibold leading-tight text-foreground">
+            {selectedLibraryTitle}
+          </h3>
+        ) : null}
         <div
           ref={previewContainerRef}
-        className="w-full lg:max-w-screen-lg"
+          className="w-full lg:max-w-screen-lg"
           onWheel={handlePreviewWheel}
           onTouchStart={handlePreviewTouchStart}
           onTouchMove={handlePreviewTouchMove}
@@ -1925,7 +1943,7 @@ function NewTradePageContent() {
           >
             <span
               data-library-preview-image
-              className="relative block aspect-[3/2] w-full overflow-hidden rounded-[4px] border-2"
+              className="relative block aspect-[16/9] w-full overflow-hidden rounded-[4px] border-2"
               style={{ borderColor: "color-mix(in srgb, rgba(var(--border-strong)) 60%, transparent)" }}
             >
               {selectedImageData ? (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,8 @@ import Card from "@/components/ui/Card";
 import {
   loadTrades,
   REGISTERED_TRADES_UPDATED_EVENT,
+  LAST_OPENED_TRADE_STORAGE_KEY,
+  LAST_HOME_SCROLL_POSITION_STORAGE_KEY,
   type StoredTrade,
 } from "@/lib/tradesStorage";
 
@@ -62,10 +64,28 @@ export default function Home() {
   const [currentDate, setCurrentDate] = useState(() => new Date());
   const [trades, setTrades] = useState<StoredTrade[]>([]);
   const [tradeFilter, setTradeFilter] = useState<"all" | "real" | "paper">("all");
+  const [highlightedTradeId, setHighlightedTradeId] = useState<string | null>(null);
+  const [pendingScrollTop, setPendingScrollTop] = useState<number | null>(null);
+  const [hasLoadedTrades, setHasLoadedTrades] = useState(false);
+  const persistScrollPosition = useCallback(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    try {
+      window.localStorage.setItem(
+        LAST_HOME_SCROLL_POSITION_STORAGE_KEY,
+        String(window.scrollY ?? window.pageYOffset ?? 0),
+      );
+    } catch {
+      // Ignore storage failures
+    }
+  }, []);
 
   const refreshTrades = useCallback(async () => {
     const nextTrades = await loadTrades();
     setTrades(nextTrades);
+    setHasLoadedTrades(true);
   }, []);
 
   useEffect(() => {
@@ -87,6 +107,93 @@ export default function Home() {
       window.removeEventListener(REGISTERED_TRADES_UPDATED_EVENT, handleUpdate);
     };
   }, [refreshTrades]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    try {
+      const storedValue = window.localStorage.getItem(LAST_HOME_SCROLL_POSITION_STORAGE_KEY);
+
+      if (storedValue) {
+        window.localStorage.removeItem(LAST_HOME_SCROLL_POSITION_STORAGE_KEY);
+        const parsed = Number(storedValue);
+
+        if (Number.isFinite(parsed)) {
+          setPendingScrollTop(parsed);
+        }
+      }
+    } catch {
+      // Ignore storage access issues
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    if (pendingScrollTop === null || !hasLoadedTrades) {
+      return;
+    }
+
+    let frameA: number | null = null;
+    let frameB: number | null = null;
+    let timeout: number | null = null;
+
+    frameA = window.requestAnimationFrame(() => {
+      frameB = window.requestAnimationFrame(() => {
+        timeout = window.setTimeout(() => {
+          window.scrollTo({ top: pendingScrollTop, behavior: "auto" });
+          setPendingScrollTop(null);
+        }, 0);
+      });
+    });
+
+    return () => {
+      if (frameA !== null) {
+        window.cancelAnimationFrame(frameA);
+      }
+
+      if (frameB !== null) {
+        window.cancelAnimationFrame(frameB);
+      }
+
+      if (timeout !== null) {
+        window.clearTimeout(timeout);
+      }
+    };
+  }, [hasLoadedTrades, pendingScrollTop]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    let highlightTimeout: number | null = null;
+
+    try {
+      const lastOpenedId = window.localStorage.getItem(LAST_OPENED_TRADE_STORAGE_KEY);
+
+      if (lastOpenedId) {
+        setHighlightedTradeId(lastOpenedId);
+        window.localStorage.removeItem(LAST_OPENED_TRADE_STORAGE_KEY);
+
+        highlightTimeout = window.setTimeout(() => {
+          setHighlightedTradeId((current) => (current === lastOpenedId ? null : current));
+        }, 2200);
+      }
+    } catch {
+      // Ignore storage access issues
+    }
+
+    return () => {
+      if (highlightTimeout !== null) {
+        window.clearTimeout(highlightTimeout);
+      }
+    };
+  }, []);
 
   const monthDays = useMemo(() => getCalendarDays(currentDate), [currentDate]);
   const todayKey = new Date().toDateString();
@@ -341,12 +448,19 @@ export default function Home() {
                     })
                     .filter((description): description is string => Boolean(description)) ?? [];
                 const shouldRenderOutcomes = Boolean(outcomeLabel) || takeProfitDescriptions.length > 0;
+                const cardClasses = [
+                  "group relative flex flex-col gap-3 rounded-2xl border border-border bg-[color:rgb(var(--surface)/0.92)] px-4 py-3 shadow-[0_14px_32px_rgba(15,23,42,0.08)] transition-all duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] hover:-translate-y-0.5 hover:border-border hover:shadow-[0_26px_46px_rgba(15,23,42,0.16)] md:flex-row md:items-center md:gap-5 md:px-5 md:py-4",
+                  highlightedTradeId === trade.id ? "last-opened-trade-card" : "",
+                ]
+                  .filter(Boolean)
+                  .join(" ");
 
                 return (
                   <li key={trade.id}>
                     <Link
                       href={`/registered-trades/${trade.id}`}
-                      className="group relative flex flex-col gap-3 rounded-2xl border border-border bg-[color:rgb(var(--surface)/0.92)] px-4 py-3 shadow-[0_14px_32px_rgba(15,23,42,0.08)] transition-all duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] hover:-translate-y-0.5 hover:border-border hover:shadow-[0_26px_46px_rgba(15,23,42,0.16)] md:flex-row md:items-center md:gap-5 md:px-5 md:py-4"
+                      className={cardClasses}
+                      onClick={persistScrollPosition}
                     >
                       {trade.isPaperTrade ? (
                         <span

--- a/components/library/LibraryCard.tsx
+++ b/components/library/LibraryCard.tsx
@@ -24,10 +24,10 @@ export function LibraryCard({
   ...buttonProps
 }: LibraryCardProps) {
   const baseVisualWrapperClassName =
-    "flex items-center justify-center overflow-hidden transition-colors duration-300";
+    "flex items-center justify-center overflow-hidden rounded-[14px] bg-gradient-to-b from-white via-white to-[#f5f7fb] ring-1 ring-black/5 transition-all duration-400";
   const resolvedVisualWrapperClassName = visualWrapperClassName
     ? `${baseVisualWrapperClassName} ${visualWrapperClassName}`
-    : `${baseVisualWrapperClassName} h-32 w-full rounded-md bg-white`;
+    : `${baseVisualWrapperClassName} h-32 w-full`;
 
   return (
     <button
@@ -36,18 +36,18 @@ export function LibraryCard({
       disabled={disabled}
       aria-pressed={isActive}
       data-active={isActive ? "true" : "false"}
-      className={`group relative flex min-w-[160px] flex-col items-center gap-4 rounded-lg border border-[#E6E6E6] bg-[#F7F7F7] p-4 text-center text-xs font-semibold text-fg shadow-[0_20px_50px_-35px_rgba(15,23,42,0.25)] transition-all duration-300 ease-out focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0 disabled:pointer-events-none disabled:opacity-50 sm:min-w-[180px] transform-gpu will-change-transform ${
+      className={`group relative flex min-w-[160px] flex-col items-center gap-3.5 rounded-xl border border-border/70 bg-gradient-to-b from-white via-white to-[rgb(var(--subtle))] px-4 pb-4 pt-4 text-center text-xs font-semibold text-fg shadow-[0_18px_48px_-28px_rgba(15,23,42,0.28)] transition-all duration-400 ease-[cubic-bezier(0.16,1,0.3,1)] focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0 disabled:pointer-events-none disabled:opacity-50 sm:min-w-[180px] transform-gpu will-change-transform ${
         isActive
-          ? "z-30 scale-[1.05] bg-white shadow-[0_28px_64px_-36px_rgba(15,23,42,0.35)]"
-          : "hover:scale-[1.02]"
+          ? "z-30 scale-[1.04] bg-white shadow-[0_24px_64px_-32px_rgba(15,23,42,0.32)]"
+          : "hover:-translate-y-0.5 hover:shadow-[0_20px_60px_-36px_rgba(15,23,42,0.26)] hover:brightness-105"
       } ${
         isDimmed && !isActive
-          ? "scale-[0.94] opacity-70 filter brightness-95 saturate-75 hover:opacity-95 hover:brightness-100 hover:saturate-100"
+          ? "scale-[0.95] opacity-75 saturate-80 transition-none"
           : ""
       } ${className}`}
     >
       {!hideLabel ? (
-        <span className="text-[11px] font-semibold uppercase tracking-[0.24em] text-muted-fg transition-colors group-hover:text-fg">
+        <span className="text-[11px] font-semibold uppercase tracking-[0.24em] text-muted-fg transition-colors duration-300 group-hover:text-fg">
           {label}
         </span>
       ) : null}

--- a/components/library/LibraryCard.tsx
+++ b/components/library/LibraryCard.tsx
@@ -36,7 +36,7 @@ export function LibraryCard({
       disabled={disabled}
       aria-pressed={isActive}
       data-active={isActive ? "true" : "false"}
-      className={`group relative flex min-w-[160px] flex-col items-center gap-3.5 rounded-xl border border-border/70 bg-gradient-to-b from-white via-white to-[rgb(var(--subtle))] px-4 pb-4 pt-4 text-center text-xs font-semibold text-fg shadow-[0_18px_48px_-28px_rgba(15,23,42,0.28)] transition-all duration-400 ease-[cubic-bezier(0.16,1,0.3,1)] focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0 disabled:pointer-events-none disabled:opacity-50 sm:min-w-[180px] transform-gpu will-change-transform ${
+      className={`group relative flex min-w-[160px] flex-col items-center gap-3.5 rounded-xl border border-[color:rgb(148_163_184/0.58)] bg-gradient-to-b from-white via-white to-[rgb(var(--subtle))] px-4 pb-4 pt-4 text-center text-xs font-semibold text-fg shadow-[0_18px_48px_-28px_rgba(15,23,42,0.28)] transition-all duration-400 ease-[cubic-bezier(0.16,1,0.3,1)] focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0 disabled:pointer-events-none disabled:opacity-50 sm:min-w-[180px] transform-gpu will-change-transform ${
         isActive
           ? "z-30 scale-[1.04] bg-white shadow-[0_24px_64px_-32px_rgba(15,23,42,0.32)]"
           : "hover:-translate-y-0.5 hover:shadow-[0_20px_60px_-36px_rgba(15,23,42,0.26)] hover:brightness-105"

--- a/components/library/LibraryCarousel.tsx
+++ b/components/library/LibraryCarousel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { LibraryCard, type LibraryCardProps } from "./LibraryCard";
 
@@ -28,8 +28,21 @@ export function LibraryCarousel({
   onMoveItem,
 }: LibraryCarouselProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const [recentlyMovedId, setRecentlyMovedId] = useState<string | null>(null);
   const hasItems = items.length > 0;
   const activeItemId = selectedId ?? items[0]?.id;
+
+  useEffect(() => {
+    if (!recentlyMovedId) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setRecentlyMovedId(null);
+    }, 520);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [recentlyMovedId]);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -59,10 +72,10 @@ export function LibraryCarousel({
   return (
     <div
       ref={containerRef}
-      className="flex h-full flex-col"
+      className="library-carousel flex h-full flex-col"
     >
       <div
-        className="flex h-full min-h-0 snap-x snap-mandatory gap-4 overflow-x-auto overflow-y-hidden py-3 pl-4 pr-4 scroll-smooth sm:pl-6 sm:pr-6 lg:flex-col lg:gap-4 lg:overflow-x-hidden lg:overflow-y-auto lg:pl-0 lg:pr-0 lg:scroll-py-6 lg:snap-y"
+        className="library-carousel-track flex h-full min-h-0 snap-x snap-mandatory gap-3.5 overflow-x-auto overflow-y-hidden py-3 pl-4 pr-4 scroll-smooth sm:pl-6 sm:pr-6 lg:flex-col lg:gap-3.5 lg:overflow-x-hidden lg:overflow-y-auto lg:pl-0 lg:pr-0 lg:scroll-py-6 lg:snap-y"
       >
         {hasItems ? (
           items.map((item, index) => {
@@ -83,7 +96,8 @@ export function LibraryCarousel({
             return (
               <div
                 key={item.id}
-                className="group relative flex snap-start justify-start lg:justify-center"
+                data-reordering={recentlyMovedId === item.id ? "true" : undefined}
+                className="library-carousel-card-wrapper group relative flex snap-start justify-start lg:justify-center"
               >
                 {showControls ? (
                   <div
@@ -115,6 +129,7 @@ export function LibraryCarousel({
                             if (!canMoveUp) {
                               return;
                             }
+                            setRecentlyMovedId(item.id);
                             onMoveItem?.(item.id, "up");
                           }}
                           className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/70 bg-[color:rgb(var(--accent)/0.08)] text-accent shadow-[0_22px_48px_-24px_rgba(15,23,42,0.55)] transition-all hover:bg-[color:rgb(var(--accent)/0.12)] focus:outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:rgb(var(--accent)/0.32)] disabled:cursor-not-allowed disabled:opacity-40"
@@ -131,6 +146,7 @@ export function LibraryCarousel({
                             if (!canMoveDown) {
                               return;
                             }
+                            setRecentlyMovedId(item.id);
                             onMoveItem?.(item.id, "down");
                           }}
                           className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/70 bg-[color:rgb(var(--accent)/0.08)] text-accent shadow-[0_22px_48px_-24px_rgba(15,23,42,0.55)] transition-all hover:bg-[color:rgb(var(--accent)/0.12)] focus:outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:rgb(var(--accent)/0.32)] disabled:cursor-not-allowed disabled:opacity-40"
@@ -147,7 +163,7 @@ export function LibraryCarousel({
                   isActive={isActive}
                   isDimmed={shouldDim}
                   data-library-carousel-item={item.id}
-                  className={`${combinedClassName} shrink-0 lg:shrink lg:mx-auto`}
+                  className={`library-carousel-card ${combinedClassName} shrink-0 lg:mx-auto lg:shrink`}
                   onClick={(event) => {
                     onSelectItem?.(item.id);
                     itemOnClick?.(event);

--- a/components/library/LibrarySection.tsx
+++ b/components/library/LibrarySection.tsx
@@ -37,6 +37,7 @@ export function LibrarySection({
 }: LibrarySectionProps) {
   const previewWrapperRef = useRef<HTMLDivElement | null>(null);
   const [previewHeight, setPreviewHeight] = useState<number | null>(null);
+  const [previewOffsetTop, setPreviewOffsetTop] = useState<number | null>(null);
   const [shouldSyncHeight, setShouldSyncHeight] = useState(false);
 
   useEffect(() => {
@@ -74,6 +75,7 @@ export function LibrarySection({
     const wrapper = previewWrapperRef.current;
     if (!wrapper) {
       setPreviewHeight(null);
+      setPreviewOffsetTop(null);
       return;
     }
 
@@ -86,12 +88,19 @@ export function LibrarySection({
       const target = currentTarget ?? findPreviewImage();
       if (!target) {
         setPreviewHeight(null);
+        setPreviewOffsetTop(null);
         return;
       }
 
-      const { height } = target.getBoundingClientRect();
+      const { height, top } = target.getBoundingClientRect();
+      const { top: wrapperTop } = wrapper.getBoundingClientRect();
+      const offsetTop = top - wrapperTop;
+
       setPreviewHeight((previousHeight) =>
         Math.abs((previousHeight ?? 0) - height) < 0.5 ? previousHeight : height,
+      );
+      setPreviewOffsetTop((previousOffset) =>
+        Math.abs((previousOffset ?? 0) - offsetTop) < 0.5 ? previousOffset : offsetTop,
       );
     };
 
@@ -147,6 +156,7 @@ export function LibrarySection({
         height: `${previewHeight}px`,
         maxHeight: `${previewHeight}px`,
         minHeight: `${previewHeight}px`,
+        marginTop: previewOffsetTop !== null ? `${previewOffsetTop}px` : undefined,
       }
     : undefined;
 

--- a/lib/tradesStorage.ts
+++ b/lib/tradesStorage.ts
@@ -97,6 +97,8 @@ export type RemovedLibraryItem = {
 };
 
 export const REGISTERED_TRADES_UPDATED_EVENT = "registered-trades-changed";
+export const LAST_OPENED_TRADE_STORAGE_KEY = "last-opened-trade-id";
+export const LAST_HOME_SCROLL_POSITION_STORAGE_KEY = "last-home-scroll-position";
 
 const SYMBOL_FLAGS: Record<string, string> = {
   EURUSD: "🇪🇺 🇺🇸",


### PR DESCRIPTION
## Summary
- measure the main preview image offset so the library carousel column aligns with the image frame on the registered trade view
- retain height synchronization while offsetting the carousel and notes to sit flush with the preview container

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e013eab908328998bc52949fe9110)