### PR TITLE
Align library preview borders

### DIFF
--- a/app/new-trade/page.tsx
+++ b/app/new-trade/page.tsx
@@ -1971,7 +1971,7 @@ function NewTradePageContent() {
           >
             <span
               data-library-preview-image
-              className="relative block aspect-[16/9] w-full overflow-hidden rounded-xl border border-[color:rgb(148_163_184/0.58)]"
+              className="relative block aspect-[16/9] w-full overflow-hidden rounded-lg border border-[color:rgb(148_163_184/0.58)]"
             >
               {selectedImageData ? (
                 <Image

--- a/app/new-trade/page.tsx
+++ b/app/new-trade/page.tsx
@@ -1971,7 +1971,7 @@ function NewTradePageContent() {
           >
             <span
               data-library-preview-image
-              className="relative block aspect-[16/9] w-full overflow-hidden rounded-lg border border-[color:rgb(148_163_184/0.58)]"
+              className="relative block aspect-[16/9] w-full overflow-hidden rounded-md border border-[color:rgb(148_163_184/0.58)]"
             >
               {selectedImageData ? (
                 <Image

--- a/app/new-trade/page.tsx
+++ b/app/new-trade/page.tsx
@@ -1971,8 +1971,7 @@ function NewTradePageContent() {
           >
             <span
               data-library-preview-image
-              className="relative block aspect-[16/9] w-full overflow-hidden rounded-[4px] border-2"
-              style={{ borderColor: "color-mix(in srgb, rgba(var(--border-strong)) 60%, transparent)" }}
+              className="relative block aspect-[16/9] w-full overflow-hidden rounded-xl border border-[color:rgb(148_163_184/0.58)]"
             >
               {selectedImageData ? (
                 <Image

--- a/app/new-trade/page.tsx
+++ b/app/new-trade/page.tsx
@@ -1971,7 +1971,7 @@ function NewTradePageContent() {
           >
             <span
               data-library-preview-image
-              className="relative block aspect-[16/9] w-full overflow-hidden rounded-md border border-[color:rgb(148_163_184/0.58)]"
+              className="relative block aspect-[16/9] w-full overflow-hidden rounded-sm border border-[color:rgb(148_163_184/0.58)]"
             >
               {selectedImageData ? (
                 <Image

--- a/app/registered-trades/[tradeId]/page.tsx
+++ b/app/registered-trades/[tradeId]/page.tsx
@@ -896,7 +896,7 @@ export default function RegisteredTradePage() {
       >
         <span
           data-library-preview-image
-          className={`relative block aspect-[16/9] w-full overflow-hidden rounded-lg border border-[color:rgb(148_163_184/0.58)] ${
+          className={`relative block aspect-[16/9] w-full overflow-hidden rounded-md border border-[color:rgb(148_163_184/0.58)] ${
             selectedImageData ? "cursor-zoom-in" : ""
           }`}
           role={selectedImageData ? "button" : undefined}

--- a/app/registered-trades/[tradeId]/page.tsx
+++ b/app/registered-trades/[tradeId]/page.tsx
@@ -874,80 +874,6 @@ export default function RegisteredTradePage() {
     </p>
   );
 
-  const primaryPreviewContent = (
-    <div
-      data-library-preview-stack
-      className="flex w-full flex-col"
-      style={{ gap: "0.5cm" }}
-    >
-      {selectedLibraryTitle ? (
-        <h3 className="text-2xl font-semibold leading-tight text-foreground">
-          {selectedLibraryTitle}
-        </h3>
-      ) : null}
-      <div
-        ref={previewContainerRef}
-        className="w-full lg:max-w-screen-lg"
-        onWheel={handlePreviewWheel}
-        onTouchStart={handlePreviewTouchStart}
-        onTouchMove={handlePreviewTouchMove}
-        onTouchEnd={handlePreviewTouchEnd}
-        onTouchCancel={handlePreviewTouchCancel}
-      >
-        <span
-          data-library-preview-image
-          className={`relative block aspect-[16/9] w-full overflow-hidden rounded-sm border border-[color:rgb(148_163_184/0.58)] ${
-            selectedImageData ? "cursor-zoom-in" : ""
-          }`}
-          role={selectedImageData ? "button" : undefined}
-          tabIndex={selectedImageData ? 0 : undefined}
-          aria-label={selectedImageData ? "Visualizza immagine della library a schermo intero" : undefined}
-          onClick={() => {
-            if (selectedImageData) {
-              setIsPreviewModalOpen(true);
-            }
-          }}
-          onKeyDown={(event) => {
-            if (!selectedImageData) {
-              return;
-            }
-
-            if (event.key === "Enter" || event.key === " ") {
-              event.preventDefault();
-              setIsPreviewModalOpen(true);
-            }
-          }}
-        >
-          {selectedImageData ? (
-            <Image
-              src={selectedImageData}
-              alt="Trade context attachment"
-              fill
-              className="h-full w-full object-contain"
-              sizes="100vw"
-              onLoadingComplete={({ naturalWidth, naturalHeight }) => {
-                if (naturalWidth > 0 && naturalHeight > 0) {
-                  setPreviewAspectRatio(naturalWidth / naturalHeight);
-                }
-              }}
-              unoptimized
-              priority
-            />
-          ) : (
-            <span className="absolute inset-0 flex flex-col items-center justify-center gap-4 bg-gradient-to-b from-[color:rgb(var(--surface)/0.94)] to-[color:rgb(var(--surface)/0.78)] text-muted-fg">
-              <EmptyLibraryIcon />
-              <span className="text-sm font-semibold uppercase tracking-[0.24em] text-muted-fg">Nessuna anteprima</span>
-              <span className="max-w-[28ch] text-center text-xs text-muted-fg/80">
-                Aggiungi immagini alle prossime operazioni per costruire un archivio visivo coerente.
-              </span>
-            </span>
-          )}
-        </span>
-      </div>
-    </div>
-  );
-  const libraryPreview = primaryPreviewContent;
-
   const modalAspectRatio = useMemo(() => {
     if (previewAspectRatio && Number.isFinite(previewAspectRatio) && previewAspectRatio > 0) {
       return `${previewAspectRatio}`;
@@ -1023,6 +949,101 @@ export default function RegisteredTradePage() {
     month: "2-digit",
     year: "numeric",
   });
+
+  const pairLabel = [activeSymbol.flag, activeSymbol.code].filter(Boolean).join(" ");
+  const tradeSummaryItems = [
+    { label: "Data", value: formattedDate },
+    { label: "Giorno", value: dayOfWeekLabel || "—" },
+    { label: "Pair", value: pairLabel || "—" },
+    { label: "Risultato", value: tradeOutcomeLabel ?? "—" },
+    { label: "Paper trade", value: trade.isPaperTrade ? "Sì" : "No" },
+  ];
+
+  const primaryPreviewContent = (
+    <div
+      data-library-preview-stack
+      className="flex w-full flex-col"
+      style={{ gap: "0.5cm" }}
+    >
+      {selectedLibraryTitle ? (
+        <h3 className="text-2xl font-semibold leading-tight text-foreground">
+          {selectedLibraryTitle}
+        </h3>
+      ) : null}
+
+      <div className="flex flex-wrap gap-3 rounded-md border border-[color:rgb(148_163_184/0.32)] bg-[color:rgb(var(--surface)/0.72)] px-4 py-3 shadow-[0_8px_24px_rgba(15,23,42,0.06)]">
+        {tradeSummaryItems.map((item) => (
+          <div key={item.label} className="flex min-w-[160px] flex-col gap-1">
+            <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-fg">
+              {item.label}
+            </span>
+            <span className="text-sm font-semibold text-foreground">{item.value}</span>
+          </div>
+        ))}
+      </div>
+
+      <div
+        ref={previewContainerRef}
+        className="w-full lg:max-w-screen-lg"
+        onWheel={handlePreviewWheel}
+        onTouchStart={handlePreviewTouchStart}
+        onTouchMove={handlePreviewTouchMove}
+        onTouchEnd={handlePreviewTouchEnd}
+        onTouchCancel={handlePreviewTouchCancel}
+      >
+        <span
+          data-library-preview-image
+          className={`relative block aspect-[16/9] w-full overflow-hidden rounded-sm border border-[color:rgb(148_163_184/0.58)] ${
+            selectedImageData ? "cursor-zoom-in" : ""
+          }`}
+          role={selectedImageData ? "button" : undefined}
+          tabIndex={selectedImageData ? 0 : undefined}
+          aria-label={selectedImageData ? "Visualizza immagine della library a schermo intero" : undefined}
+          onClick={() => {
+            if (selectedImageData) {
+              setIsPreviewModalOpen(true);
+            }
+          }}
+          onKeyDown={(event) => {
+            if (!selectedImageData) {
+              return;
+            }
+
+            if (event.key === "Enter" || event.key === " ") {
+              event.preventDefault();
+              setIsPreviewModalOpen(true);
+            }
+          }}
+        >
+          {selectedImageData ? (
+            <Image
+              src={selectedImageData}
+              alt="Trade context attachment"
+              fill
+              className="h-full w-full object-contain"
+              sizes="100vw"
+              onLoadingComplete={({ naturalWidth, naturalHeight }) => {
+                if (naturalWidth > 0 && naturalHeight > 0) {
+                  setPreviewAspectRatio(naturalWidth / naturalHeight);
+                }
+              }}
+              unoptimized
+              priority
+            />
+          ) : (
+            <span className="absolute inset-0 flex flex-col items-center justify-center gap-4 bg-gradient-to-b from-[color:rgb(var(--surface)/0.94)] to-[color:rgb(var(--surface)/0.78)] text-muted-fg">
+              <EmptyLibraryIcon />
+              <span className="text-sm font-semibold uppercase tracking-[0.24em] text-muted-fg">Nessuna anteprima</span>
+              <span className="max-w-[28ch] text-center text-xs text-muted-fg/80">
+                Aggiungi immagini alle prossime operazioni per costruire un archivio visivo coerente.
+              </span>
+            </span>
+          )}
+        </span>
+      </div>
+    </div>
+  );
+  const libraryPreview = primaryPreviewContent;
 
   const openTimeDisplay = getDateTimeDisplay(trade.openTime);
   const closeTimeDisplay = getDateTimeDisplay(trade.closeTime);

--- a/app/registered-trades/[tradeId]/page.tsx
+++ b/app/registered-trades/[tradeId]/page.tsx
@@ -896,7 +896,7 @@ export default function RegisteredTradePage() {
       >
         <span
           data-library-preview-image
-          className={`relative block aspect-[16/9] w-full overflow-hidden rounded-md border border-[color:rgb(148_163_184/0.58)] ${
+          className={`relative block aspect-[16/9] w-full overflow-hidden rounded-sm border border-[color:rgb(148_163_184/0.58)] ${
             selectedImageData ? "cursor-zoom-in" : ""
           }`}
           role={selectedImageData ? "button" : undefined}

--- a/app/registered-trades/[tradeId]/page.tsx
+++ b/app/registered-trades/[tradeId]/page.tsx
@@ -896,10 +896,9 @@ export default function RegisteredTradePage() {
       >
         <span
           data-library-preview-image
-          className={`relative block aspect-[16/9] w-full overflow-hidden rounded-[4px] border-2 ${
+          className={`relative block aspect-[16/9] w-full overflow-hidden rounded-xl border border-[color:rgb(148_163_184/0.58)] ${
             selectedImageData ? "cursor-zoom-in" : ""
           }`}
-          style={{ borderColor: "color-mix(in srgb, rgba(var(--border-strong)) 60%, transparent)" }}
           role={selectedImageData ? "button" : undefined}
           tabIndex={selectedImageData ? 0 : undefined}
           aria-label={selectedImageData ? "Visualizza immagine della library a schermo intero" : undefined}

--- a/app/registered-trades/[tradeId]/page.tsx
+++ b/app/registered-trades/[tradeId]/page.tsx
@@ -896,7 +896,7 @@ export default function RegisteredTradePage() {
       >
         <span
           data-library-preview-image
-          className={`relative block aspect-[16/9] w-full overflow-hidden rounded-xl border border-[color:rgb(148_163_184/0.58)] ${
+          className={`relative block aspect-[16/9] w-full overflow-hidden rounded-lg border border-[color:rgb(148_163_184/0.58)] ${
             selectedImageData ? "cursor-zoom-in" : ""
           }`}
           role={selectedImageData ? "button" : undefined}

--- a/components/library/LibraryCard.tsx
+++ b/components/library/LibraryCard.tsx
@@ -24,7 +24,7 @@ export function LibraryCard({
   ...buttonProps
 }: LibraryCardProps) {
   const baseVisualWrapperClassName =
-    "flex items-center justify-center overflow-hidden rounded-lg bg-gradient-to-b from-white via-white to-[#f5f7fb] ring-1 ring-black/5 transition-all duration-400";
+    "flex items-center justify-center overflow-hidden rounded-md bg-gradient-to-b from-white via-white to-[#f5f7fb] ring-1 ring-black/5 transition-all duration-400";
   const resolvedVisualWrapperClassName = visualWrapperClassName
     ? `${baseVisualWrapperClassName} ${visualWrapperClassName}`
     : `${baseVisualWrapperClassName} h-32 w-full`;
@@ -36,7 +36,7 @@ export function LibraryCard({
       disabled={disabled}
       aria-pressed={isActive}
       data-active={isActive ? "true" : "false"}
-      className={`group relative flex min-w-[160px] flex-col items-center gap-3.5 rounded-lg border border-[color:rgb(148_163_184/0.58)] bg-gradient-to-b from-white via-white to-[rgb(var(--subtle))] px-4 pb-4 pt-4 text-center text-xs font-semibold text-fg shadow-[0_18px_48px_-28px_rgba(15,23,42,0.28)] transition-all duration-400 ease-[cubic-bezier(0.16,1,0.3,1)] focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0 disabled:pointer-events-none disabled:opacity-50 sm:min-w-[180px] transform-gpu will-change-transform ${
+      className={`group relative flex min-w-[160px] flex-col items-center gap-3.5 rounded-md border border-[color:rgb(148_163_184/0.58)] bg-gradient-to-b from-white via-white to-[rgb(var(--subtle))] px-4 pb-4 pt-4 text-center text-xs font-semibold text-fg shadow-[0_18px_48px_-28px_rgba(15,23,42,0.28)] transition-all duration-400 ease-[cubic-bezier(0.16,1,0.3,1)] focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0 disabled:pointer-events-none disabled:opacity-50 sm:min-w-[180px] transform-gpu will-change-transform ${
         isActive
           ? "z-30 scale-[1.04] bg-white shadow-[0_24px_64px_-32px_rgba(15,23,42,0.32)]"
           : "hover:-translate-y-0.5 hover:shadow-[0_20px_60px_-36px_rgba(15,23,42,0.26)] hover:brightness-105"

--- a/components/library/LibraryCard.tsx
+++ b/components/library/LibraryCard.tsx
@@ -24,7 +24,7 @@ export function LibraryCard({
   ...buttonProps
 }: LibraryCardProps) {
   const baseVisualWrapperClassName =
-    "flex items-center justify-center overflow-hidden rounded-[14px] bg-gradient-to-b from-white via-white to-[#f5f7fb] ring-1 ring-black/5 transition-all duration-400";
+    "flex items-center justify-center overflow-hidden rounded-lg bg-gradient-to-b from-white via-white to-[#f5f7fb] ring-1 ring-black/5 transition-all duration-400";
   const resolvedVisualWrapperClassName = visualWrapperClassName
     ? `${baseVisualWrapperClassName} ${visualWrapperClassName}`
     : `${baseVisualWrapperClassName} h-32 w-full`;
@@ -36,7 +36,7 @@ export function LibraryCard({
       disabled={disabled}
       aria-pressed={isActive}
       data-active={isActive ? "true" : "false"}
-      className={`group relative flex min-w-[160px] flex-col items-center gap-3.5 rounded-xl border border-[color:rgb(148_163_184/0.58)] bg-gradient-to-b from-white via-white to-[rgb(var(--subtle))] px-4 pb-4 pt-4 text-center text-xs font-semibold text-fg shadow-[0_18px_48px_-28px_rgba(15,23,42,0.28)] transition-all duration-400 ease-[cubic-bezier(0.16,1,0.3,1)] focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0 disabled:pointer-events-none disabled:opacity-50 sm:min-w-[180px] transform-gpu will-change-transform ${
+      className={`group relative flex min-w-[160px] flex-col items-center gap-3.5 rounded-lg border border-[color:rgb(148_163_184/0.58)] bg-gradient-to-b from-white via-white to-[rgb(var(--subtle))] px-4 pb-4 pt-4 text-center text-xs font-semibold text-fg shadow-[0_18px_48px_-28px_rgba(15,23,42,0.28)] transition-all duration-400 ease-[cubic-bezier(0.16,1,0.3,1)] focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0 disabled:pointer-events-none disabled:opacity-50 sm:min-w-[180px] transform-gpu will-change-transform ${
         isActive
           ? "z-30 scale-[1.04] bg-white shadow-[0_24px_64px_-32px_rgba(15,23,42,0.32)]"
           : "hover:-translate-y-0.5 hover:shadow-[0_20px_60px_-36px_rgba(15,23,42,0.26)] hover:brightness-105"

--- a/components/library/LibraryCard.tsx
+++ b/components/library/LibraryCard.tsx
@@ -24,7 +24,7 @@ export function LibraryCard({
   ...buttonProps
 }: LibraryCardProps) {
   const baseVisualWrapperClassName =
-    "flex items-center justify-center overflow-hidden rounded-md bg-gradient-to-b from-white via-white to-[#f5f7fb] ring-1 ring-black/5 transition-all duration-400";
+    "flex items-center justify-center overflow-hidden rounded-sm bg-gradient-to-b from-white via-white to-[#f5f7fb] ring-1 ring-black/5 transition-all duration-400";
   const resolvedVisualWrapperClassName = visualWrapperClassName
     ? `${baseVisualWrapperClassName} ${visualWrapperClassName}`
     : `${baseVisualWrapperClassName} h-32 w-full`;
@@ -36,7 +36,7 @@ export function LibraryCard({
       disabled={disabled}
       aria-pressed={isActive}
       data-active={isActive ? "true" : "false"}
-      className={`group relative flex min-w-[160px] flex-col items-center gap-3.5 rounded-md border border-[color:rgb(148_163_184/0.58)] bg-gradient-to-b from-white via-white to-[rgb(var(--subtle))] px-4 pb-4 pt-4 text-center text-xs font-semibold text-fg shadow-[0_18px_48px_-28px_rgba(15,23,42,0.28)] transition-all duration-400 ease-[cubic-bezier(0.16,1,0.3,1)] focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0 disabled:pointer-events-none disabled:opacity-50 sm:min-w-[180px] transform-gpu will-change-transform ${
+      className={`group relative flex min-w-[160px] flex-col items-center gap-3.5 rounded-sm border border-[color:rgb(148_163_184/0.58)] bg-gradient-to-b from-white via-white to-[rgb(var(--subtle))] px-4 pb-4 pt-4 text-center text-xs font-semibold text-fg shadow-[0_18px_48px_-28px_rgba(15,23,42,0.28)] transition-all duration-400 ease-[cubic-bezier(0.16,1,0.3,1)] focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0 disabled:pointer-events-none disabled:opacity-50 sm:min-w-[180px] transform-gpu will-change-transform ${
         isActive
           ? "z-30 scale-[1.04] bg-white shadow-[0_24px_64px_-32px_rgba(15,23,42,0.32)]"
           : "hover:-translate-y-0.5 hover:shadow-[0_20px_60px_-36px_rgba(15,23,42,0.26)] hover:brightness-105"

--- a/components/library/LibraryCarousel.tsx
+++ b/components/library/LibraryCarousel.tsx
@@ -173,7 +173,7 @@ export function LibraryCarousel({
             );
           })
         ) : (
-          <div className="flex h-[180px] w-[220px] max-w-[220px] shrink-0 snap-start items-center justify-center rounded-2xl border border-dashed border-muted/40 bg-white/60 text-xs font-semibold uppercase tracking-[0.2em] text-muted-fg sm:w-[252px] sm:max-w-[252px] lg:mx-auto lg:w-full lg:max-w-[calc(100%-1rem)]">
+          <div className="flex h-[180px] w-[220px] max-w-[220px] shrink-0 snap-start items-center justify-center rounded-xl border border-dashed border-muted/40 bg-white/60 text-xs font-semibold uppercase tracking-[0.2em] text-muted-fg sm:w-[252px] sm:max-w-[252px] lg:mx-auto lg:w-full lg:max-w-[calc(100%-1rem)]">
             Nessuna card
           </div>
         )}

--- a/components/library/LibraryCarousel.tsx
+++ b/components/library/LibraryCarousel.tsx
@@ -173,7 +173,7 @@ export function LibraryCarousel({
             );
           })
         ) : (
-          <div className="flex h-[180px] w-[220px] max-w-[220px] shrink-0 snap-start items-center justify-center rounded-xl border border-dashed border-muted/40 bg-white/60 text-xs font-semibold uppercase tracking-[0.2em] text-muted-fg sm:w-[252px] sm:max-w-[252px] lg:mx-auto lg:w-full lg:max-w-[calc(100%-1rem)]">
+          <div className="flex h-[180px] w-[220px] max-w-[220px] shrink-0 snap-start items-center justify-center rounded-md border border-dashed border-muted/40 bg-white/60 text-xs font-semibold uppercase tracking-[0.2em] text-muted-fg sm:w-[252px] sm:max-w-[252px] lg:mx-auto lg:w-full lg:max-w-[calc(100%-1rem)]">
             Nessuna card
           </div>
         )}

--- a/components/library/LibraryCarousel.tsx
+++ b/components/library/LibraryCarousel.tsx
@@ -173,7 +173,7 @@ export function LibraryCarousel({
             );
           })
         ) : (
-          <div className="flex h-[180px] w-[220px] max-w-[220px] shrink-0 snap-start items-center justify-center rounded-md border border-dashed border-muted/40 bg-white/60 text-xs font-semibold uppercase tracking-[0.2em] text-muted-fg sm:w-[252px] sm:max-w-[252px] lg:mx-auto lg:w-full lg:max-w-[calc(100%-1rem)]">
+          <div className="flex h-[180px] w-[220px] max-w-[220px] shrink-0 snap-start items-center justify-center rounded-sm border border-dashed border-muted/40 bg-white/60 text-xs font-semibold uppercase tracking-[0.2em] text-muted-fg sm:w-[252px] sm:max-w-[252px] lg:mx-auto lg:w-full lg:max-w-[calc(100%-1rem)]">
             Nessuna card
           </div>
         )}


### PR DESCRIPTION
## Summary
- align the main preview image border styling with the carousel containers on the new trade and registered trade pages

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f66baf2b48328a4f1cbcb5910f9a6)