### PR TITLE
Align preview image borders with carousel styling

### DIFF
--- a/app/new-trade/page.tsx
+++ b/app/new-trade/page.tsx
@@ -1971,8 +1971,7 @@ function NewTradePageContent() {
           >
             <span
               data-library-preview-image
-              className="relative block aspect-[16/9] w-full overflow-hidden rounded-[4px] border-2"
-              style={{ borderColor: "color-mix(in srgb, rgba(var(--border-strong)) 60%, transparent)" }}
+              className="relative block aspect-[16/9] w-full overflow-hidden rounded-xl border border-[color:rgb(148_163_184/0.58)]"
             >
               {selectedImageData ? (
                 <Image

--- a/app/registered-trades/[tradeId]/page.tsx
+++ b/app/registered-trades/[tradeId]/page.tsx
@@ -896,10 +896,9 @@ export default function RegisteredTradePage() {
       >
         <span
           data-library-preview-image
-          className={`relative block aspect-[16/9] w-full overflow-hidden rounded-[4px] border-2 ${
+          className={`relative block aspect-[16/9] w-full overflow-hidden rounded-xl border border-[color:rgb(148_163_184/0.58)] ${
             selectedImageData ? "cursor-zoom-in" : ""
           }`}
-          style={{ borderColor: "color-mix(in srgb, rgba(var(--border-strong)) 60%, transparent)" }}
           role={selectedImageData ? "button" : undefined}
           tabIndex={selectedImageData ? 0 : undefined}
           aria-label={selectedImageData ? "Visualizza immagine della library a schermo intero" : undefined}


### PR DESCRIPTION
## Summary
- update main preview image containers on new trade and registered trade pages to match carousel border styling

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f66baf2b48328a4f1cbcb5910f9a6)