### PR TITLE
Make registered trade cards a consistent height

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -449,7 +449,7 @@ export default function Home() {
                     .filter((description): description is string => Boolean(description)) ?? [];
                 const shouldRenderOutcomes = Boolean(outcomeLabel) || takeProfitDescriptions.length > 0;
                 const cardClasses = [
-                  "group relative flex flex-col gap-3 rounded-2xl border border-border bg-[color:rgb(var(--surface)/0.92)] px-4 py-3 shadow-[0_14px_32px_rgba(15,23,42,0.08)] transition-all duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] hover:-translate-y-0.5 hover:border-border hover:shadow-[0_26px_46px_rgba(15,23,42,0.16)] md:flex-row md:items-center md:gap-5 md:px-5 md:py-4",
+                  "group relative flex min-h-[190px] flex-col gap-3 rounded-2xl border border-border bg-[color:rgb(var(--surface)/0.92)] px-4 py-3 shadow-[0_14px_32px_rgba(15,23,42,0.08)] transition-all duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] hover:-translate-y-0.5 hover:border-border hover:shadow-[0_26px_46px_rgba(15,23,42,0.16)] md:min-h-[112px] md:flex-row md:items-center md:gap-5 md:px-5 md:py-4",
                   highlightedTradeId === trade.id ? "last-opened-trade-card" : "",
                 ]
                   .filter(Boolean)
@@ -503,7 +503,7 @@ export default function Home() {
                           ) : null}
                         </div>
                         {takeProfitDescriptions.length > 0 ? (
-                          <div className="mt-2 flex flex-col items-center gap-1 text-[0.58rem] font-medium tracking-[0.08em] text-muted-fg">
+                          <div className="mt-2 flex max-h-20 flex-col items-center gap-1 overflow-y-auto text-[0.58rem] font-medium tracking-[0.08em] text-muted-fg">
                             {takeProfitDescriptions.map((description) => (
                               <span key={description}>{description}</span>
                             ))}
@@ -543,7 +543,7 @@ export default function Home() {
                               </span>
                             ) : null}
                             {takeProfitDescriptions.length > 0 ? (
-                              <div className="flex flex-col gap-1 text-[0.6rem] font-medium text-muted-fg">
+                              <div className="flex max-h-16 flex-col gap-1 overflow-y-auto text-[0.6rem] font-medium text-muted-fg">
                                 {takeProfitDescriptions.map((description) => (
                                   <span key={description} className="tracking-[0.08em]">
                                     {description}


### PR DESCRIPTION
## Summary
- set consistent minimum heights for registered trade cards on the home page
- constrain take profit outcome sections to prevent cards from expanding unevenly

## Testing
- npm run dev -- --hostname 0.0.0.0 --port 3000 *(fails: missing supabaseUrl environment configuration)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69232464e95c8328a94b9dd924873488)