### PR TITLE
Add library summary blocks for trade pages

### DIFF
--- a/app/new-trade/page.tsx
+++ b/app/new-trade/page.tsx
@@ -932,6 +932,52 @@ function NewTradePageContent() {
     return getLibraryCardTitle(fallbackIndex === -1 ? 0 : fallbackIndex);
   }, [libraryItems, selectedLibraryItem]);
 
+  const librarySummaryItems = useMemo(
+    () => {
+      const tradeDateLabel = selectedDate.toLocaleDateString(undefined, {
+        day: "2-digit",
+        month: "2-digit",
+        year: "numeric",
+      });
+
+      const capitalizedWeekday =
+        dayOfWeekLabel.length > 0
+          ? `${dayOfWeekLabel.charAt(0).toUpperCase()}${dayOfWeekLabel.slice(1)}`
+          : "—";
+
+      const pairLabel = selectedSymbol
+        ? `${selectedSymbol.flag} ${selectedSymbol.code}`
+        : "—";
+
+      const outcomeLabel =
+        tradeOutcome === "profit"
+          ? "Profit"
+          : tradeOutcome === "loss"
+            ? "Loss"
+            : "—";
+
+      const paperTradeLabel = isRealTrade ? "No" : "Sì";
+
+      return [
+        { label: "Data", value: `${tradeDateLabel} • ${capitalizedWeekday}` },
+        { label: "Pair", value: pairLabel },
+        { label: "Risultato", value: outcomeLabel },
+        { label: "Paper trade", value: paperTradeLabel },
+        { label: "Apertura", value: openTimeDisplay.timeLabel },
+        { label: "Chiusura", value: closeTimeDisplay.timeLabel },
+      ];
+    },
+    [
+      closeTimeDisplay.timeLabel,
+      dayOfWeekLabel,
+      isRealTrade,
+      openTimeDisplay.timeLabel,
+      selectedDate,
+      selectedSymbol,
+      tradeOutcome,
+    ],
+  );
+
   const canNavigateLibrary = libraryItems.length > 1;
 
   const goToAdjacentLibraryItem = useCallback(
@@ -1946,6 +1992,18 @@ function NewTradePageContent() {
             {selectedLibraryTitle}
           </h3>
         ) : null}
+        <div className="rounded-xl border border-border/80 bg-[color:rgb(var(--surface)/0.85)] px-4 py-3 text-sm shadow-sm">
+          <div className="grid w-full gap-3 sm:grid-cols-2">
+            {librarySummaryItems.map((item) => (
+              <div key={item.label} className="flex flex-col gap-1">
+                <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-fg">
+                  {item.label}
+                </span>
+                <span className="text-sm font-medium text-fg">{item.value}</span>
+              </div>
+            ))}
+          </div>
+        </div>
         <div
           ref={previewContainerRef}
           className="w-full lg:max-w-screen-lg"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -449,7 +449,7 @@ export default function Home() {
                     .filter((description): description is string => Boolean(description)) ?? [];
                 const shouldRenderOutcomes = Boolean(outcomeLabel) || takeProfitDescriptions.length > 0;
                 const cardClasses = [
-                  "group relative flex flex-col gap-3 rounded-2xl border border-border bg-[color:rgb(var(--surface)/0.92)] px-4 py-3 shadow-[0_14px_32px_rgba(15,23,42,0.08)] transition-all duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] hover:-translate-y-0.5 hover:border-border hover:shadow-[0_26px_46px_rgba(15,23,42,0.16)] md:flex-row md:items-center md:gap-5 md:px-5 md:py-4",
+                  "group relative flex min-h-[9.5rem] flex-col gap-3 rounded-2xl border border-border bg-[color:rgb(var(--surface)/0.92)] px-4 py-3 shadow-[0_14px_32px_rgba(15,23,42,0.08)] transition-all duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] hover:-translate-y-0.5 hover:border-border hover:shadow-[0_26px_46px_rgba(15,23,42,0.16)] md:min-h-[5.75rem] md:flex-row md:items-center md:gap-5 md:px-5 md:py-4",
                   highlightedTradeId === trade.id ? "last-opened-trade-card" : "",
                 ]
                   .filter(Boolean)

--- a/app/registered-trades/[tradeId]/page.tsx
+++ b/app/registered-trades/[tradeId]/page.tsx
@@ -508,6 +508,58 @@ export default function RegisteredTradePage() {
       weekday: "long",
     });
   }, [selectedDate]);
+  const librarySummaryItems = useMemo(() => {
+    const trade = state.trade;
+
+    const tradeDateLabel = selectedDate
+      ? selectedDate.toLocaleDateString(undefined, {
+          day: "2-digit",
+          month: "2-digit",
+          year: "numeric",
+        })
+      : "—";
+
+    const capitalizedWeekday = dayOfWeekLabel
+      ? `${dayOfWeekLabel.charAt(0).toUpperCase()}${dayOfWeekLabel.slice(1)}`
+      : "—";
+
+    if (!trade) {
+      return [
+        { label: "Data", value: `${tradeDateLabel} • ${capitalizedWeekday}` },
+        { label: "Pair", value: "—" },
+        { label: "Risultato", value: "—" },
+        { label: "Paper trade", value: "—" },
+        { label: "Apertura", value: "--:--" },
+        { label: "Chiusura", value: "--:--" },
+      ];
+    }
+
+    const activeSymbolSummary =
+      availableSymbols.find((symbol) => symbol.code === trade.symbolCode) ?? {
+        code: trade.symbolCode,
+        flag: trade.symbolFlag,
+      };
+
+    const outcomeLabel =
+      trade.tradeOutcome === "profit"
+        ? "Profit"
+        : trade.tradeOutcome === "loss"
+          ? "Loss"
+          : "—";
+
+    const openTimeDisplay = getDateTimeDisplay(trade.openTime);
+    const closeTimeDisplay = getDateTimeDisplay(trade.closeTime);
+    const paperTradeLabel = trade.isPaperTrade ? "Sì" : "No";
+
+    return [
+      { label: "Data", value: `${tradeDateLabel} • ${capitalizedWeekday}` },
+      { label: "Pair", value: `${activeSymbolSummary.flag} ${activeSymbolSummary.code}` },
+      { label: "Risultato", value: outcomeLabel },
+      { label: "Paper trade", value: paperTradeLabel },
+      { label: "Apertura", value: openTimeDisplay.timeLabel },
+      { label: "Chiusura", value: closeTimeDisplay.timeLabel },
+    ];
+  }, [dayOfWeekLabel, selectedDate, state.trade]);
   const openTimeValue = useMemo(() => {
     const iso = state.trade?.openTime;
     if (!iso) {
@@ -877,19 +929,31 @@ export default function RegisteredTradePage() {
   const primaryPreviewContent = (
     <div
       data-library-preview-stack
-      className="flex w-full flex-col"
-      style={{ gap: "0.5cm" }}
-    >
-      {selectedLibraryTitle ? (
-        <h3 className="text-2xl font-semibold leading-tight text-foreground">
-          {selectedLibraryTitle}
-        </h3>
-      ) : null}
-      <div
-        ref={previewContainerRef}
-        className="w-full lg:max-w-screen-lg"
-        onWheel={handlePreviewWheel}
-        onTouchStart={handlePreviewTouchStart}
+    className="flex w-full flex-col"
+    style={{ gap: "0.5cm" }}
+  >
+    {selectedLibraryTitle ? (
+      <h3 className="text-2xl font-semibold leading-tight text-foreground">
+        {selectedLibraryTitle}
+      </h3>
+    ) : null}
+    <div className="rounded-xl border border-border/80 bg-[color:rgb(var(--surface)/0.85)] px-4 py-3 text-sm shadow-sm">
+      <div className="grid w-full gap-3 sm:grid-cols-2">
+        {librarySummaryItems.map((item) => (
+          <div key={item.label} className="flex flex-col gap-1">
+            <span className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-fg">
+              {item.label}
+            </span>
+            <span className="text-sm font-medium text-fg">{item.value}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+    <div
+      ref={previewContainerRef}
+      className="w-full lg:max-w-screen-lg"
+      onWheel={handlePreviewWheel}
+      onTouchStart={handlePreviewTouchStart}
         onTouchMove={handlePreviewTouchMove}
         onTouchEnd={handlePreviewTouchEnd}
         onTouchCancel={handlePreviewTouchCancel}


### PR DESCRIPTION
## Summary
- add compact main-data summary blocks to the Library sections on new-trade and registered-trade pages
- display key trade details above the carousel preview with consistent styling

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69232464e95c8328a94b9dd924873488)