### PR TITLE
Implement compounded profit factor calculation utility

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import Button from "@/components/ui/Button";
 import Card from "@/components/ui/Card";
@@ -67,6 +67,8 @@ export default function Home() {
   const [highlightedTradeId, setHighlightedTradeId] = useState<string | null>(null);
   const [pendingScrollTop, setPendingScrollTop] = useState<number | null>(null);
   const [hasLoadedTrades, setHasLoadedTrades] = useState(false);
+  const [showWinrateInfo, setShowWinrateInfo] = useState(false);
+  const winrateInfoRef = useRef<HTMLDivElement | null>(null);
   const persistScrollPosition = useCallback(() => {
     if (typeof window === "undefined") {
       return;
@@ -195,6 +197,22 @@ export default function Home() {
     };
   }, []);
 
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (winrateInfoRef.current?.contains(event.target as Node)) {
+        return;
+      }
+
+      setShowWinrateInfo(false);
+    };
+
+    window.addEventListener("click", handleClickOutside);
+
+    return () => {
+      window.removeEventListener("click", handleClickOutside);
+    };
+  }, []);
+
   const monthDays = useMemo(() => getCalendarDays(currentDate), [currentDate]);
   const todayKey = new Date().toDateString();
   const activeMonth = currentDate.getMonth();
@@ -221,6 +239,20 @@ export default function Home() {
   }, [orderedTrades, tradeFilter]);
 
   const totalTrades = filteredTrades.length;
+
+  const outcomeStats = useMemo(() => {
+    const tradesWithOutcome = trades.filter((trade) => Boolean(trade.tradeOutcome));
+    const profitableTrades = tradesWithOutcome.filter((trade) => trade.tradeOutcome === "profit");
+    const percentage = tradesWithOutcome.length
+      ? (profitableTrades.length / tradesWithOutcome.length) * 100
+      : 0;
+
+    return {
+      profitable: profitableTrades.length,
+      total: tradesWithOutcome.length,
+      percentage,
+    };
+  }, [trades]);
 
   const outcomesByDay = useMemo(() => {
     const map = new Map<string, { outcome: "profit" | "loss"; timestamp: number }[]>();
@@ -285,6 +317,38 @@ export default function Home() {
       </header>
 
       <div className="mt-16 flex w-full flex-col items-center gap-12 pb-16">
+        <div className="w-full max-w-3xl self-center text-left sm:max-w-4xl">
+          <div className="flex flex-col gap-2 rounded-2xl border border-border bg-[color:rgb(var(--surface)/0.92)] px-6 py-5 shadow-[0_14px_32px_rgba(15,23,42,0.08)]">
+            <div className="flex items-center gap-2 text-base font-semibold text-fg">
+              <span>Operazioni in guadagno</span>
+              <div className="relative" ref={winrateInfoRef}>
+                <button
+                  type="button"
+                  onClick={() => setShowWinrateInfo((current) => !current)}
+                  className="interactive-area grid h-6 w-6 place-items-center rounded-full border border-border bg-[color:rgb(var(--surface)/0.92)] text-[0.7rem] font-semibold text-muted-fg transition-colors hover:text-fg"
+                  aria-label="Informazioni sulla percentuale di trade vincenti"
+                >
+                  i
+                </button>
+                {showWinrateInfo ? (
+                  <div className="absolute left-1/2 top-full z-20 mt-3 w-72 -translate-x-1/2 rounded-2xl bg-[rgb(24,24,27)] px-4 py-3 text-sm font-medium text-white shadow-[0_22px_44px_rgba(15,23,42,0.36)]">
+                    <span className="absolute left-1/2 top-0 -translate-x-1/2 -translate-y-2 border-x-[9px] border-x-transparent border-b-[9px] border-b-[rgb(24,24,27)]" aria-hidden="true" />
+                    La percentuale di trade vincenti, il numero di operazioni vincenti diviso per il numero totale di operazioni chiuse.
+                  </div>
+                ) : null}
+              </div>
+            </div>
+            <div className="flex items-baseline gap-3">
+              <span className="text-3xl font-semibold text-fg">
+                {outcomeStats.percentage.toLocaleString("it-IT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}%
+              </span>
+              <span className="text-sm font-medium text-muted-fg">
+                {outcomeStats.profitable}/{outcomeStats.total}
+              </span>
+            </div>
+          </div>
+        </div>
+
         <Card className="w-full max-w-3xl self-center p-8 sm:max-w-4xl sm:p-10">
           <div className="flex items-center justify-between">
             <button

--- a/lib/profitFactor.ts
+++ b/lib/profitFactor.ts
@@ -1,0 +1,87 @@
+import { calculateOverallPips } from "./pips";
+import type { StoredTrade } from "./tradesStorage";
+
+function normalizeRiskPercentage(value: number | null | undefined) {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return null;
+  }
+
+  // Accept both fractional values (e.g., 0.01) and percentage points (e.g., 1 for 1%)
+  return value > 1 ? value / 100 : value;
+}
+
+function getTradeTimestamp(trade: StoredTrade) {
+  const candidates = [trade.date, trade.openTime, trade.closeTime, trade.createdAt];
+
+  for (const candidate of candidates) {
+    if (!candidate) {
+      continue;
+    }
+
+    const parsed = new Date(candidate);
+    const timestamp = parsed.getTime();
+
+    if (!Number.isNaN(timestamp)) {
+      return timestamp;
+    }
+  }
+
+  return 0;
+}
+
+export function calculateProfitFactor({
+  trades,
+  initialCapital,
+}: {
+  trades: StoredTrade[];
+  initialCapital: number | null | undefined;
+}) {
+  const startingCapital =
+    typeof initialCapital === "number" && Number.isFinite(initialCapital) && initialCapital > 0
+      ? initialCapital
+      : null;
+
+  if (startingCapital === null) {
+    return { profitFactor: null, totalProfit: 0, totalLoss: 0 };
+  }
+
+  const orderedTrades = [...trades].sort((a, b) => getTradeTimestamp(a) - getTradeTimestamp(b));
+
+  let capital = startingCapital;
+  let totalProfit = 0;
+  let totalLoss = 0;
+
+  for (const trade of orderedTrades) {
+    const outcome = trade.tradeOutcome;
+    const pips = calculateOverallPips(trade.pips);
+    const riskPercent = normalizeRiskPercentage(trade.risk.find((entry) => typeof entry === "number" && !Number.isNaN(entry)));
+
+    if (!riskPercent || (outcome === "profit" && (!pips || pips <= 0))) {
+      continue;
+    }
+
+    if (outcome === "profit") {
+      const profitAmount = capital * riskPercent * pips;
+
+      if (Number.isFinite(profitAmount) && profitAmount > 0) {
+        totalProfit += profitAmount;
+        capital += profitAmount;
+      }
+
+      continue;
+    }
+
+    if (outcome === "loss") {
+      const lossAmount = capital * riskPercent;
+
+      if (Number.isFinite(lossAmount) && lossAmount > 0) {
+        totalLoss += lossAmount;
+        capital -= lossAmount;
+      }
+    }
+  }
+
+  const profitFactor = totalLoss > 0 ? totalProfit / totalLoss : null;
+
+  return { profitFactor, totalProfit, totalLoss };
+}


### PR DESCRIPTION
## Summary
- add a profit factor calculator that compounds capital after each trade
- normalize risk percentages and use overall pips to derive trade profits and losses

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69283b6fbebc83288a03453d0d0d1be6)