### PR TITLE
Compute profit factor using rolling capital

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import Button from "@/components/ui/Button";
 import Card from "@/components/ui/Card";
@@ -13,6 +13,7 @@ import {
 } from "@/lib/tradesStorage";
 
 const WEEKDAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+const INITIAL_CAPITAL_STORAGE_KEY = "initial-capital";
 
 function getCalendarDays(activeDate: Date) {
   const year = activeDate.getFullYear();
@@ -67,6 +68,13 @@ export default function Home() {
   const [highlightedTradeId, setHighlightedTradeId] = useState<string | null>(null);
   const [pendingScrollTop, setPendingScrollTop] = useState<number | null>(null);
   const [hasLoadedTrades, setHasLoadedTrades] = useState(false);
+  const [showWinrateInfo, setShowWinrateInfo] = useState(false);
+  const [initialCapital, setInitialCapital] = useState<number | null>(() => {
+    const envCapital = Number(process.env.NEXT_PUBLIC_INITIAL_CAPITAL ?? "");
+
+    return Number.isFinite(envCapital) ? envCapital : null;
+  });
+  const winrateInfoRef = useRef<HTMLDivElement | null>(null);
   const persistScrollPosition = useCallback(() => {
     if (typeof window === "undefined") {
       return;
@@ -171,6 +179,23 @@ export default function Home() {
       return;
     }
 
+    try {
+      const storedCapital = window.localStorage.getItem(INITIAL_CAPITAL_STORAGE_KEY);
+      const parsed = storedCapital ? Number(storedCapital) : null;
+
+      if (parsed !== null && Number.isFinite(parsed)) {
+        setInitialCapital(parsed);
+      }
+    } catch {
+      // Ignore storage access issues
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
     let highlightTimeout: number | null = null;
 
     try {
@@ -192,6 +217,22 @@ export default function Home() {
       if (highlightTimeout !== null) {
         window.clearTimeout(highlightTimeout);
       }
+    };
+  }, []);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (winrateInfoRef.current?.contains(event.target as Node)) {
+        return;
+      }
+
+      setShowWinrateInfo(false);
+    };
+
+    window.addEventListener("click", handleClickOutside);
+
+    return () => {
+      window.removeEventListener("click", handleClickOutside);
     };
   }, []);
 
@@ -221,6 +262,80 @@ export default function Home() {
   }, [orderedTrades, tradeFilter]);
 
   const totalTrades = filteredTrades.length;
+
+  const outcomeStats = useMemo(() => {
+    const tradesWithOutcome = trades.filter((trade) => Boolean(trade.tradeOutcome));
+    const profitableTrades = tradesWithOutcome.filter((trade) => trade.tradeOutcome === "profit");
+    const percentage = tradesWithOutcome.length
+      ? (profitableTrades.length / tradesWithOutcome.length) * 100
+      : 0;
+
+    return {
+      profitable: profitableTrades.length,
+      total: tradesWithOutcome.length,
+      percentage,
+    };
+  }, [trades]);
+
+  const profitFactorStats = useMemo(() => {
+    if (initialCapital === null) {
+      return { profitFactor: null };
+    }
+
+    let capital = initialCapital;
+    let totalProfit = 0;
+    let totalLoss = 0;
+
+    const ordered = filteredTrades
+      .filter((trade) => trade.tradeOutcome === "profit" || trade.tradeOutcome === "loss")
+      .map((trade) => ({ trade, timestamp: getTradeTimestamp(trade) }))
+      .sort((a, b) => a.timestamp - b.timestamp);
+
+    const getFirstFiniteValue = (values: Array<number | null | undefined>) => {
+      for (const value of values) {
+        if (typeof value === "number" && Number.isFinite(value)) {
+          return value;
+        }
+      }
+
+      return null;
+    };
+
+    for (const { trade } of ordered) {
+      const riskPercent = getFirstFiniteValue(trade.risk);
+
+      if (riskPercent === null || riskPercent <= 0) {
+        continue;
+      }
+
+      const riskFraction = riskPercent / 100;
+
+      if (trade.tradeOutcome === "profit") {
+        const pipsValue = getFirstFiniteValue(trade.pips);
+
+        if (pipsValue === null) {
+          continue;
+        }
+
+        const normalizedPips = Math.max(pipsValue, 0);
+        const tradeProfit = capital * riskFraction * normalizedPips;
+
+        totalProfit += tradeProfit;
+        capital += tradeProfit;
+      } else {
+        const tradeLoss = capital * riskFraction;
+
+        totalLoss += tradeLoss;
+        capital -= tradeLoss;
+      }
+    }
+
+    if (totalLoss === 0) {
+      return { profitFactor: null };
+    }
+
+    return { profitFactor: totalProfit / totalLoss };
+  }, [filteredTrades, initialCapital]);
 
   const outcomesByDay = useMemo(() => {
     const map = new Map<string, { outcome: "profit" | "loss"; timestamp: number }[]>();
@@ -285,6 +400,49 @@ export default function Home() {
       </header>
 
       <div className="mt-16 flex w-full flex-col items-center gap-12 pb-16">
+        <div className="w-full max-w-3xl self-center text-left sm:max-w-4xl">
+          <div className="flex flex-col gap-2 rounded-2xl border border-border bg-[color:rgb(var(--surface)/0.92)] px-6 py-5 shadow-[0_14px_32px_rgba(15,23,42,0.08)]">
+            <div className="flex items-center gap-2 text-base font-semibold text-fg">
+              <span>Operazioni in guadagno</span>
+              <div className="relative" ref={winrateInfoRef}>
+                <button
+                  type="button"
+                  onClick={() => setShowWinrateInfo((current) => !current)}
+                  className="interactive-area grid h-6 w-6 place-items-center rounded-full border border-border bg-[color:rgb(var(--surface)/0.92)] text-[0.7rem] font-semibold text-muted-fg transition-colors hover:text-fg"
+                  aria-label="Informazioni sulla percentuale di trade vincenti"
+                >
+                  i
+                </button>
+                {showWinrateInfo ? (
+                  <div className="absolute left-1/2 top-full z-20 mt-3 w-72 -translate-x-1/2 rounded-2xl bg-[rgb(24,24,27)] px-4 py-3 text-sm font-medium text-white shadow-[0_22px_44px_rgba(15,23,42,0.36)]">
+                    <span className="absolute left-1/2 top-0 -translate-x-1/2 -translate-y-2 border-x-[9px] border-x-transparent border-b-[9px] border-b-[rgb(24,24,27)]" aria-hidden="true" />
+                    La percentuale di trade vincenti, il numero di operazioni vincenti diviso per il numero totale di operazioni chiuse.
+                  </div>
+                ) : null}
+              </div>
+            </div>
+            <div className="flex items-baseline gap-3">
+              <span className="text-3xl font-semibold text-fg">
+                {outcomeStats.percentage.toLocaleString("it-IT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}%
+              </span>
+              <span className="text-sm font-medium text-muted-fg">
+                {outcomeStats.profitable}/{outcomeStats.total}
+              </span>
+            </div>
+            <div className="mt-1 flex items-center justify-between text-sm font-medium text-muted-fg">
+              <span>Profit Factor</span>
+              <span className="text-base font-semibold text-fg">
+                {profitFactorStats.profitFactor !== null
+                  ? profitFactorStats.profitFactor.toLocaleString("it-IT", {
+                      minimumFractionDigits: 2,
+                      maximumFractionDigits: 2,
+                    })
+                  : "—"}
+              </span>
+            </div>
+          </div>
+        </div>
+
         <Card className="w-full max-w-3xl self-center p-8 sm:max-w-4xl sm:p-10">
           <div className="flex items-center justify-between">
             <button


### PR DESCRIPTION
## Summary
- load the initial capital from configuration/local storage for profit calculations
- compute the profit factor by updating capital after each trade based on risk percent and pips
- surface the calculated profit factor alongside the home page performance indicator

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69283b6fbebc83288a03453d0d0d1be6)